### PR TITLE
fix(toolbar): move actions after filters

### DIFF
--- a/packages/module/src/DataViewToolbar/DataViewToolbar.tsx
+++ b/packages/module/src/DataViewToolbar/DataViewToolbar.tsx
@@ -35,14 +35,14 @@ export const DataViewToolbar: React.FC<DataViewToolbarProps> = ({ className, oui
             {bulkSelect}
           </ToolbarItem>
         )}
-        {actions && (
-          <ToolbarItem variant={ToolbarItemVariant['overflow-menu']}>
-            {actions}
-          </ToolbarItem>
-        )}
         {filters && (
           <ToolbarItem variant={ToolbarItemVariant['search-filter']}>
             {filters}
+          </ToolbarItem>
+        )}
+        {actions && (
+          <ToolbarItem variant={ToolbarItemVariant['overflow-menu']}>
+            {actions}
           </ToolbarItem>
         )}
         {pagination && (


### PR DESCRIPTION
[RHCLOUD-36511](https://issues.redhat.com/browse/RHCLOUD-36511)

Move actions after filters

