### PR TITLE
fix: add react-code-editor dev dependency

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -25,7 +25,7 @@ jobs:
            node_modules
            **/node_modules
           key: ${{ runner.os }}-npm-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile
         if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v4
         id: dist
@@ -61,7 +61,7 @@ jobs:
            node_modules
            **/node_modules
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile
         if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v4
         id: lint-cache
@@ -99,7 +99,7 @@ jobs:
            **/node_modules
            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile 
         if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v4
         id: dist
@@ -140,7 +140,7 @@ jobs:
            **/node_modules
            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile
         if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v4
         id: dist
@@ -185,7 +185,7 @@ jobs:
             **/node_modules
             ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile 
         if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v4
         id: dist
@@ -225,7 +225,7 @@ jobs:
             **/node_modules
             ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile 
         if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v4
         id: dist

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-npm-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - run: npm install --frozen-lockfile --legacy-peer-deps
+      - run: npm install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - run: npm run build
         name: Build data view

--- a/package-lock.json
+++ b/package-lock.json
@@ -3813,9 +3813,9 @@
       }
     },
     "node_modules/@patternfly/ast-helpers": {
-      "version": "1.4.0-alpha.136",
-      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.136.tgz",
-      "integrity": "sha512-xB2sapSNa+TFRsD2aAym8SUOUtgKVCcH++lcWzdb62x4N4je6U9OYoODLB5CvvmOVSXulq3r34l9pojfEk3jPA==",
+      "version": "1.4.0-alpha.137",
+      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.137.tgz",
+      "integrity": "sha512-spdANBmCV2qMYzQDUlLa63HGm24p1vZbsN4QAsqREWHsOA+6WhME6Itc/TJimjuzwYlGvQj1Jv8q4LxyPGYKMw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.4.1",
@@ -3826,16 +3826,16 @@
       }
     },
     "node_modules/@patternfly/documentation-framework": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.1.2.tgz",
-      "integrity": "sha512-RJh9v8B3BTs5ABqqCEnEpJXM7piQGavy607F7RX5CJhnw4dUSawy0qOByin0cdzNhFkxoe+DF2QN3enzrw1kOw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.1.3.tgz",
+      "integrity": "sha512-s5VKxGw6WNjRVtYd+23NvgeuH2/U35zE7cD4+v97P5p7UB7r/nHBApIxOH1DJ4RklqcDVGcM8k1tkvBW8AWRTQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.3",
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.136",
+        "@patternfly/ast-helpers": "^1.4.0-alpha.137",
         "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
         "autoprefixer": "9.8.6",
         "babel-loader": "^9.1.3",
@@ -27645,490 +27645,6 @@
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
-    },
-    "packages/module/node_modules/@patternfly/documentation-framework": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.0.8.tgz",
-      "integrity": "sha512-56e5o1xzGHL2USSOIq7Yq0y2VNwQoJOdN1WlLxjllRUj+NtGEketCIvWctczTxsoL3tUQ3qlu+/gUOQt6X+xcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.3",
-        "@babel/preset-env": "^7.24.3",
-        "@babel/preset-react": "^7.24.1",
-        "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.124",
-        "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
-        "autoprefixer": "9.8.6",
-        "babel-loader": "^9.1.3",
-        "camelcase-css": "2.0.1",
-        "chokidar": "4.0.0",
-        "clean-webpack-plugin": "4.0.0",
-        "codesandbox": "2.2.0",
-        "commander": "4.1.1",
-        "copy-webpack-plugin": "11.0.0",
-        "css-loader": "6.7.3",
-        "detab": "2.0.3",
-        "express": "4.21.0",
-        "file-loader": "6.2.0",
-        "file-saver": "1.3.8",
-        "fs-extra": "9.0.1",
-        "glob": "9.0.0",
-        "handlebars": "4.7.7",
-        "hast-to-hyperscript": "9.0.0",
-        "hast-util-to-text": "2.0.0",
-        "html-formatter": "0.1.9",
-        "html-webpack-plugin": "5.5.0",
-        "js-yaml": "3.14.0",
-        "mdast-util-to-hast": "9.1.1",
-        "mdurl": "1.0.1",
-        "mini-css-extract-plugin": "2.7.5",
-        "null-loader": "4.0.1",
-        "parse-entities": "2.0.0",
-        "path-browserify": "1.0.1",
-        "postcss": "8.4.32",
-        "postcss-loader": "7.1.0",
-        "process": "^0.11.10",
-        "puppeteer": "19.11.1",
-        "puppeteer-cluster": "0.23.0",
-        "react-docgen": "5.3.1",
-        "react-ssr-prepass": "1.5.0",
-        "remark-footnotes": "1.0.0",
-        "remark-frontmatter": "2.0.0",
-        "remark-mdx": "2.0.0-next.8",
-        "remark-mdxjs": "2.0.0-next.8",
-        "remark-parse": "8.0.3",
-        "remark-squeeze-paragraphs": "4.0.0",
-        "responsive-loader": "3.1.2",
-        "sharp": "0.32.6",
-        "style-to-object": "0.3.0",
-        "to-vfile": "6.1.0",
-        "typedoc": "0.23.0",
-        "typescript": "4.7.4",
-        "unified": "9.1.0",
-        "unist-util-remove": "2.0.0",
-        "unist-util-visit": "2.0.3",
-        "url-loader": "4.1.0",
-        "vfile-reporter": "6.0.1",
-        "webpack": "5.76.3",
-        "webpack-bundle-analyzer": "4.8.0",
-        "webpack-cli": "5.0.1",
-        "webpack-dev-server": "4.13.1",
-        "webpack-merge": "5.8.0"
-      },
-      "bin": {
-        "pf-docs-framework": "scripts/cli/cli.js"
-      },
-      "peerDependencies": {
-        "@patternfly/patternfly": "^6.0.0",
-        "@patternfly/react-code-editor": "^6.0.0",
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-table": "^6.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "packages/module/node_modules/@patternfly/documentation-framework/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/module/node_modules/@patternfly/documentation-framework/node_modules/typedoc": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.0.tgz",
-      "integrity": "sha512-pcVvGbxRJDPuXKt7VV9gGMhR36kJc4IlQOnLAqfPQWujzHM9C4hW7gLjfpbXJXuwXkJehuFhPMOinga8mYFcjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 14.14"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x"
-      }
-    },
-    "packages/module/node_modules/@patternfly/documentation-framework/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "packages/module/node_modules/@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/@webassemblyjs/ast": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/helper-wasm-section": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-opt": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
-        "@webassemblyjs/wast-printer": "1.11.1"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
-      }
-    },
-    "packages/module/node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "packages/module/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/module/node_modules/chokidar": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-      "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/module/node_modules/es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/module/node_modules/fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/module/node_modules/glob": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.0.0.tgz",
-      "integrity": "sha512-7rdoWzT8/4f1yEe/cMdBug2lmzmYMYU9h4RNNiavPHajhcxt7kkxrOvwSnIPkZMjLQb9BXv7nFoKmTnPPklMyA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^7.3.0",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/module/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/module/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/module/node_modules/readdirp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/module/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "packages/module/node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "packages/module/node_modules/webpack": {
-      "version": "5.76.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
-      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/wasm-edit": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.7.6",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.10.0",
-        "es-module-lexer": "^0.9.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
     }
   },
   "dependencies": {
@@ -29295,8 +28811,7 @@
           "version": "7.21.0-placeholder-for-preset-env.2",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
           "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -30273,7 +29788,6 @@
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
       "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "state-local": "^1.0.6"
       }
@@ -30283,7 +29797,6 @@
       "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
       "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@monaco-editor/loader": "^1.4.0"
       }
@@ -30375,8 +29888,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
       "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "13.2.2",
@@ -30541,9 +30053,9 @@
       "optional": true
     },
     "@patternfly/ast-helpers": {
-      "version": "1.4.0-alpha.125",
-      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.125.tgz",
-      "integrity": "sha512-WvN5CYFmTYOztt3wMidJq8xLdu6jhpHzjPvYxMN2wlh7v0QJEHaplvJGZH/E8ZUcri/ni2OoLVIe2KcuRwrxng==",
+      "version": "1.4.0-alpha.137",
+      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.137.tgz",
+      "integrity": "sha512-spdANBmCV2qMYzQDUlLa63HGm24p1vZbsN4QAsqREWHsOA+6WhME6Itc/TJimjuzwYlGvQj1Jv8q4LxyPGYKMw==",
       "dev": true,
       "requires": {
         "acorn": "^8.4.1",
@@ -30554,16 +30066,16 @@
       }
     },
     "@patternfly/documentation-framework": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.0.6.tgz",
-      "integrity": "sha512-YXXzj7K2lmAZbvgTDSTd4AJTW6xpJ6G/C3jCMxGGMXevYJ1wGHQQnBVbGQvQcZPgIwU5nv3+FmnyfldJhRwQtw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.1.3.tgz",
+      "integrity": "sha512-s5VKxGw6WNjRVtYd+23NvgeuH2/U35zE7cD4+v97P5p7UB7r/nHBApIxOH1DJ4RklqcDVGcM8k1tkvBW8AWRTQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.24.3",
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.122",
+        "@patternfly/ast-helpers": "^1.4.0-alpha.137",
         "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
         "autoprefixer": "9.8.6",
         "babel-loader": "^9.1.3",
@@ -30575,7 +30087,7 @@
         "copy-webpack-plugin": "11.0.0",
         "css-loader": "6.7.3",
         "detab": "2.0.3",
-        "express": "4.21.0",
+        "express": "4.21.2",
         "file-loader": "6.2.0",
         "file-saver": "1.3.8",
         "fs-extra": "9.0.1",
@@ -30595,8 +30107,8 @@
         "postcss": "8.4.32",
         "postcss-loader": "7.1.0",
         "process": "^0.11.10",
-        "puppeteer": "19.11.1",
-        "puppeteer-cluster": "0.23.0",
+        "puppeteer": "^23.6.1",
+        "puppeteer-cluster": "^0.24.0",
         "react-docgen": "5.3.1",
         "react-ssr-prepass": "1.5.0",
         "remark-footnotes": "1.0.0",
@@ -30946,143 +30458,11 @@
         "xmldoc": "^1.3.0"
       },
       "dependencies": {
-        "@puppeteer/browsers": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
-          "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.7",
-            "extract-zip": "^2.0.1",
-            "progress": "^2.0.3",
-            "proxy-agent": "^6.4.0",
-            "semver": "^7.6.3",
-            "tar-fs": "^3.0.6",
-            "unbzip2-stream": "^1.4.3",
-            "yargs": "^17.7.2"
-          }
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "chromium-bidi": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
-          "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
-          "dev": true,
-          "requires": {
-            "mitt": "3.0.1",
-            "urlpattern-polyfill": "10.0.0",
-            "zod": "3.23.8"
-          }
-        },
         "commander": {
           "version": "12.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
           "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
           "dev": true
-        },
-        "cosmiconfig": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-          "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.1",
-            "import-fresh": "^3.3.0",
-            "js-yaml": "^4.1.0",
-            "parse-json": "^5.2.0"
-          }
-        },
-        "devtools-protocol": {
-          "version": "0.0.1367902",
-          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
-          "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
-        "mitt": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-          "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-          "dev": true
-        },
-        "puppeteer": {
-          "version": "23.9.0",
-          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.9.0.tgz",
-          "integrity": "sha512-WfB8jGwFV+qrD9dcJJVvWPFJBU6kxeu2wxJz9WooDGfM3vIiKLgzImEDBxUQnCBK/2cXB3d4dV6gs/LLpgfLDg==",
-          "dev": true,
-          "requires": {
-            "@puppeteer/browsers": "2.4.1",
-            "chromium-bidi": "0.8.0",
-            "cosmiconfig": "^9.0.0",
-            "devtools-protocol": "0.0.1367902",
-            "puppeteer-core": "23.9.0",
-            "typed-query-selector": "^2.12.0"
-          }
-        },
-        "puppeteer-cluster": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/puppeteer-cluster/-/puppeteer-cluster-0.24.0.tgz",
-          "integrity": "sha512-zHPoNsrwkFLKFtgJJv2aC13EbMASQsE048uZd7CyikEXcl+sc1Nf6PMFb9kMoZI7/zMYxvuP658o2mw079ZZyQ==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4"
-          }
-        },
-        "puppeteer-core": {
-          "version": "23.9.0",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.9.0.tgz",
-          "integrity": "sha512-hLVrav2HYMVdK0YILtfJwtnkBAwNOztUdR4aJ5YKDvgsbtagNr6urUJk9HyjRA9e+PaLI3jzJ0wM7A4jSZ7Qxw==",
-          "dev": true,
-          "requires": {
-            "@puppeteer/browsers": "2.4.1",
-            "chromium-bidi": "0.8.0",
-            "debug": "^4.3.7",
-            "devtools-protocol": "0.0.1367902",
-            "typed-query-selector": "^2.12.0",
-            "ws": "^8.18.0"
-          }
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
-        },
-        "tar-fs": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-          "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-          "dev": true,
-          "requires": {
-            "bare-fs": "^2.1.1",
-            "bare-path": "^2.1.0",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "dev": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
         }
       }
     },
@@ -31091,7 +30471,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.0.0.tgz",
       "integrity": "sha512-TnI/NNkizzWTzdVZWmpyEPKXgsOoUeklk8Xlgtl7II/+5juLjlt0wXTMhL35F59Rzd0YohGs251zXAwJbn6vIQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@monaco-editor/react": "^4.6.0",
         "@patternfly/react-core": "^6.0.0",
@@ -31129,13 +30508,14 @@
     "@patternfly/react-data-view": {
       "version": "file:packages/module",
       "requires": {
-        "@patternfly/documentation-framework": "6.0.8",
-        "@patternfly/patternfly": "6.0.0",
+        "@patternfly/documentation-framework": "^6.0.12",
+        "@patternfly/patternfly": "^6.0.0",
         "@patternfly/patternfly-a11y": "^5.0.0",
-        "@patternfly/react-component-groups": "6.0.0",
-        "@patternfly/react-core": "6.0.0",
-        "@patternfly/react-icons": "6.0.0",
-        "@patternfly/react-table": "6.0.0",
+        "@patternfly/react-code-editor": "^6.0.0",
+        "@patternfly/react-component-groups": "^6.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "@types/react-router-dom": "^5.3.3",
@@ -31147,384 +30527,12 @@
         "react-router-dom": "^6.28.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.4.5"
-      },
-      "dependencies": {
-        "@patternfly/documentation-framework": {
-          "version": "6.0.8",
-          "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.0.8.tgz",
-          "integrity": "sha512-56e5o1xzGHL2USSOIq7Yq0y2VNwQoJOdN1WlLxjllRUj+NtGEketCIvWctczTxsoL3tUQ3qlu+/gUOQt6X+xcQ==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.24.3",
-            "@babel/preset-env": "^7.24.3",
-            "@babel/preset-react": "^7.24.1",
-            "@mdx-js/util": "1.6.16",
-            "@patternfly/ast-helpers": "^1.4.0-alpha.124",
-            "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
-            "autoprefixer": "9.8.6",
-            "babel-loader": "^9.1.3",
-            "camelcase-css": "2.0.1",
-            "chokidar": "4.0.0",
-            "clean-webpack-plugin": "4.0.0",
-            "codesandbox": "2.2.0",
-            "commander": "4.1.1",
-            "copy-webpack-plugin": "11.0.0",
-            "css-loader": "6.7.3",
-            "detab": "2.0.3",
-            "express": "4.21.0",
-            "file-loader": "6.2.0",
-            "file-saver": "1.3.8",
-            "fs-extra": "9.0.1",
-            "glob": "9.0.0",
-            "handlebars": "4.7.7",
-            "hast-to-hyperscript": "9.0.0",
-            "hast-util-to-text": "2.0.0",
-            "html-formatter": "0.1.9",
-            "html-webpack-plugin": "5.5.0",
-            "js-yaml": "3.14.0",
-            "mdast-util-to-hast": "9.1.1",
-            "mdurl": "1.0.1",
-            "mini-css-extract-plugin": "2.7.5",
-            "null-loader": "4.0.1",
-            "parse-entities": "2.0.0",
-            "path-browserify": "1.0.1",
-            "postcss": "8.4.32",
-            "postcss-loader": "7.1.0",
-            "process": "^0.11.10",
-            "puppeteer": "19.11.1",
-            "puppeteer-cluster": "0.23.0",
-            "react-docgen": "5.3.1",
-            "react-ssr-prepass": "1.5.0",
-            "remark-footnotes": "1.0.0",
-            "remark-frontmatter": "2.0.0",
-            "remark-mdx": "2.0.0-next.8",
-            "remark-mdxjs": "2.0.0-next.8",
-            "remark-parse": "8.0.3",
-            "remark-squeeze-paragraphs": "4.0.0",
-            "responsive-loader": "3.1.2",
-            "sharp": "0.32.6",
-            "style-to-object": "0.3.0",
-            "to-vfile": "6.1.0",
-            "typedoc": "0.23.0",
-            "typescript": "4.7.4",
-            "unified": "9.1.0",
-            "unist-util-remove": "2.0.0",
-            "unist-util-visit": "2.0.3",
-            "url-loader": "4.1.0",
-            "vfile-reporter": "6.0.1",
-            "webpack": "5.76.3",
-            "webpack-bundle-analyzer": "4.8.0",
-            "webpack-cli": "5.0.1",
-            "webpack-dev-server": "4.13.1",
-            "webpack-merge": "5.8.0"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "5.1.6",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-              "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "typedoc": {
-              "version": "0.23.0",
-              "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.0.tgz",
-              "integrity": "sha512-pcVvGbxRJDPuXKt7VV9gGMhR36kJc4IlQOnLAqfPQWujzHM9C4hW7gLjfpbXJXuwXkJehuFhPMOinga8mYFcjA==",
-              "dev": true,
-              "requires": {
-                "lunr": "^2.3.9",
-                "marked": "^4.0.16",
-                "minimatch": "^5.1.0",
-                "shiki": "^0.10.1"
-              }
-            },
-            "typescript": {
-              "version": "4.7.4",
-              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-              "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-              "dev": true
-            }
-          }
-        },
-        "@types/estree": {
-          "version": "0.0.51",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-          "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-          "dev": true
-        },
-        "@webassemblyjs/ast": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-          "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/helper-numbers": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
-          }
-        },
-        "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-          "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-          "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-buffer": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-          "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-numbers": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-          "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-            "@webassemblyjs/helper-api-error": "1.11.1",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-          "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-wasm-section": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-          "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-buffer": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/wasm-gen": "1.11.1"
-          }
-        },
-        "@webassemblyjs/ieee754": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-          "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-          "dev": true,
-          "requires": {
-            "@xtuc/ieee754": "^1.2.0"
-          }
-        },
-        "@webassemblyjs/leb128": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-          "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-          "dev": true,
-          "requires": {
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/utf8": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-          "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-          "dev": true
-        },
-        "@webassemblyjs/wasm-edit": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-          "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-buffer": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/helper-wasm-section": "1.11.1",
-            "@webassemblyjs/wasm-gen": "1.11.1",
-            "@webassemblyjs/wasm-opt": "1.11.1",
-            "@webassemblyjs/wasm-parser": "1.11.1",
-            "@webassemblyjs/wast-printer": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wasm-gen": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-          "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/ieee754": "1.11.1",
-            "@webassemblyjs/leb128": "1.11.1",
-            "@webassemblyjs/utf8": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wasm-opt": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-          "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-buffer": "1.11.1",
-            "@webassemblyjs/wasm-gen": "1.11.1",
-            "@webassemblyjs/wasm-parser": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wasm-parser": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-          "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-api-error": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/ieee754": "1.11.1",
-            "@webassemblyjs/leb128": "1.11.1",
-            "@webassemblyjs/utf8": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wast-printer": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-          "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "chokidar": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-          "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
-          "dev": true,
-          "requires": {
-            "readdirp": "^4.0.1"
-          }
-        },
-        "es-module-lexer": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-          "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-9.0.0.tgz",
-          "integrity": "sha512-7rdoWzT8/4f1yEe/cMdBug2lmzmYMYU9h4RNNiavPHajhcxt7kkxrOvwSnIPkZMjLQb9BXv7nFoKmTnPPklMyA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "minimatch": "^7.3.0",
-            "minipass": "^4.2.4",
-            "path-scurry": "^1.5.0"
-          }
-        },
-        "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "minipass": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-          "dev": true
-        },
-        "readdirp": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-          "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        },
-        "webpack": {
-          "version": "5.76.3",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
-          "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^0.0.51",
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/wasm-edit": "1.11.1",
-            "@webassemblyjs/wasm-parser": "1.11.1",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.7.6",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.10.0",
-            "es-module-lexer": "^0.9.0",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.1.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.1.3",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@patternfly/react-icons": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0.tgz",
-      "integrity": "sha512-ZFrsBVKrAp0DZrPOss98OA/EVUL4F0frXhR1uBId9+3ZrRArdKTgYgmQUCeSzMbxnSlxpmm3a2L05XQ36VUVbw==",
-      "requires": {}
+      "integrity": "sha512-ZFrsBVKrAp0DZrPOss98OA/EVUL4F0frXhR1uBId9+3ZrRArdKTgYgmQUCeSzMbxnSlxpmm3a2L05XQ36VUVbw=="
     },
     "@patternfly/react-styles": {
       "version": "6.0.0",
@@ -31569,108 +30577,57 @@
       "dev": true
     },
     "@puppeteer/browsers": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
-      "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
       "dev": true,
       "requires": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
       },
       "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        },
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
         },
         "tar-fs": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+          "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "mkdirp-classic": "^0.5.2",
+            "bare-fs": "^2.1.1",
+            "bare-path": "^2.1.0",
             "pump": "^3.0.0",
-            "tar-stream": "^2.1.4"
+            "tar-stream": "^3.1.5"
           }
         },
         "tar-stream": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
           "dev": true,
           "requires": {
-            "bl": "^4.0.3",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
+            "b4a": "^1.6.4",
+            "fast-fifo": "^1.2.0",
+            "streamx": "^2.15.0"
           }
         }
       }
@@ -32006,8 +30963,7 @@
       "version": "14.5.2",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
       "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -32105,78 +31061,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "@types/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
-      "dev": true,
-      "peer": true
-    },
-    "@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true,
-      "peer": true
-    },
-    "@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "dev": true,
-      "peer": true
-    },
-    "@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/d3-color": "*"
-      }
-    },
-    "@types/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
-      "dev": true,
-      "peer": true
-    },
-    "@types/d3-scale": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
-      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/d3-time": "*"
-      }
-    },
-    "@types/d3-shape": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
-      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/d3-path": "*"
-      }
-    },
-    "@types/d3-time": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
-      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
-      "dev": true,
-      "peer": true
-    },
-    "@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "dev": true,
-      "peer": true
     },
     "@types/eslint": {
       "version": "9.6.1",
@@ -32711,187 +31595,23 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
-      }
-    },
-    "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
-      "dev": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
-      "dev": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
-      "dev": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
-      "dev": true,
-      "peer": true
-    },
-    "@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
-      }
-    },
-    "@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
-      "dev": true,
-      "peer": true
-    },
-    "@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
-      }
-    },
-    "@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
-      }
-    },
-    "@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
-      }
-    },
-    "@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
-      }
-    },
-    "@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
     "@webpack-cli/configtest": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -32956,30 +31676,19 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true,
-      "requires": {}
-    },
-    "acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-private-class-elements": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-1.0.0.tgz",
       "integrity": "sha512-zYNcZtxKgVCg1brS39BEou86mIao1EV7eeREG+6WMwKbuYTeivRRs6S2XdWnboRde6G9wKh2w+WBydEyJsJ6mg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-static-class-features": {
       "version": "1.0.0",
@@ -33072,8 +31781,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -34309,12 +33017,14 @@
       }
     },
     "chromium-bidi": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
-      "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
       "dev": true,
       "requires": {
-        "mitt": "3.0.0"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
       }
     },
     "ci-info": {
@@ -34940,9 +33650,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true
     },
     "cookie-signature": {
@@ -35157,15 +33867,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -35451,105 +34152,6 @@
         }
       }
     },
-    "d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "internmap": "1 - 2"
-      }
-    },
-    "d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "dev": true,
-      "peer": true
-    },
-    "d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "dev": true,
-      "peer": true
-    },
-    "d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "dev": true,
-      "peer": true
-    },
-    "d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "d3-color": "1 - 3"
-      }
-    },
-    "d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "dev": true,
-      "peer": true
-    },
-    "d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      }
-    },
-    "d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "d3-path": "^3.1.0"
-      }
-    },
-    "d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "d3-array": "2 - 3"
-      }
-    },
-    "d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "d3-time": "1 - 3"
-      }
-    },
-    "d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "dev": true,
-      "peer": true
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -35662,8 +34264,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -35843,23 +34444,6 @@
         }
       }
     },
-    "delaunator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
-      "dev": true,
-      "peer": true
-    },
-    "delaunay-find": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
-      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "delaunator": "^4.0.0"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -35919,9 +34503,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1107588",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "dev": true
     },
     "diff-sequences": {
@@ -36310,13 +34894,6 @@
         "safe-array-concat": "^1.1.2"
       }
     },
-    "es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
-      "dev": true,
-      "peer": true
-    },
     "es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
@@ -36586,8 +35163,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-standard-with-typescript": {
       "version": "23.0.0",
@@ -36603,8 +35179,7 @@
           "version": "17.0.0",
           "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
           "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -36904,8 +35479,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.37.1",
@@ -36959,8 +35533,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
       "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -37158,9 +35731,9 @@
       }
     },
     "express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
@@ -37168,7 +35741,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -37182,7 +35755,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -37861,15 +36434,14 @@
       }
     },
     "get-uri": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "dev": true,
       "requires": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.2.0"
+        "debug": "^4.3.4"
       }
     },
     "getos": {
@@ -38539,8 +37111,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -38805,13 +37376,6 @@
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       }
-    },
-    "internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "dev": true,
-      "peer": true
     },
     "interpret": {
       "version": "3.1.1",
@@ -40277,8 +38841,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -42068,9 +40631,9 @@
       }
     },
     "mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true
     },
     "mkdirp": {
@@ -42087,13 +40650,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
-    },
-    "monaco-editor": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
-      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
-      "dev": true,
-      "peer": true
     },
     "moniker": {
       "version": "0.1.2",
@@ -42274,39 +40830,6 @@
       "dev": true,
       "requires": {
         "minimatch": "^3.0.2"
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
       }
     },
     "node-fetch-npm": {
@@ -42760,29 +41283,26 @@
       "dev": true
     },
     "pac-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
+      "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
       "dev": true,
       "requires": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.4"
+        "socks-proxy-agent": "^8.0.5"
       },
       "dependencies": {
         "agent-base": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-          "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4"
-          }
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+          "dev": true
         },
         "http-proxy-agent": {
           "version": "7.0.2",
@@ -42795,12 +41315,12 @@
           }
         },
         "https-proxy-agent": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-          "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
           "dev": true,
           "requires": {
-            "agent-base": "^7.0.2",
+            "agent-base": "^7.1.2",
             "debug": "4"
           }
         },
@@ -42821,12 +41341,12 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-          "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+          "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
           "dev": true,
           "requires": {
-            "agent-base": "^7.1.1",
+            "agent-base": "^7.1.2",
             "debug": "^4.3.4",
             "socks": "^2.8.3"
           }
@@ -43107,9 +41627,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "path-type": {
@@ -43278,8 +41798,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
       "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.5",
@@ -43553,29 +42072,26 @@
       }
     },
     "proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "requires": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
+        "pac-proxy-agent": "^7.1.0",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.5"
       },
       "dependencies": {
         "agent-base": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-          "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4"
-          }
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+          "dev": true
         },
         "http-proxy-agent": {
           "version": "7.0.2",
@@ -43588,12 +42104,12 @@
           }
         },
         "https-proxy-agent": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-          "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
           "dev": true,
           "requires": {
-            "agent-base": "^7.0.2",
+            "agent-base": "^7.1.2",
             "debug": "4"
           }
         },
@@ -43626,12 +42142,12 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-          "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+          "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
           "dev": true,
           "requires": {
-            "agent-base": "^7.1.1",
+            "agent-base": "^7.1.2",
             "debug": "^4.3.4",
             "socks": "^2.8.3"
           }
@@ -43705,17 +42221,17 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.11.1.tgz",
-      "integrity": "sha512-39olGaX2djYUdhaQQHDZ0T0GwEp+5f9UB9HmEP0qHfdQHIq0xGQZuAZ5TLnJIc/88SrPLpEflPC+xUqOTv3c5g==",
+      "version": "23.10.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.10.3.tgz",
+      "integrity": "sha512-ODG+L9vCSPkQ1j+yDtNDdkSsWt2NXNrQO5C8MlwkYgE2hYnXdqVRbBpsHnoP7+EULJJKbWyR2Q4BdfohjQor3A==",
       "dev": true,
       "requires": {
-        "@puppeteer/browsers": "0.5.0",
-        "cosmiconfig": "8.1.3",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.11.1"
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.8.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.10.3",
+        "typed-query-selector": "^2.12.0"
       },
       "dependencies": {
         "argparse": {
@@ -43725,15 +42241,15 @@
           "dev": true
         },
         "cosmiconfig": {
-          "version": "8.1.3",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-          "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+          "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
           "dev": true,
           "requires": {
-            "import-fresh": "^3.2.1",
+            "env-paths": "^2.2.1",
+            "import-fresh": "^3.3.0",
             "js-yaml": "^4.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0"
+            "parse-json": "^5.2.0"
           }
         },
         "js-yaml": {
@@ -43744,117 +42260,40 @@
           "requires": {
             "argparse": "^2.0.1"
           }
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-          "dev": true
         }
       }
     },
     "puppeteer-cluster": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-cluster/-/puppeteer-cluster-0.23.0.tgz",
-      "integrity": "sha512-108terIWDzPrQopmoYSPd5yDoy3FGJ2dNnoGMkGYPs6xtkdhgaECwpfZkzaRToMQPZibUOz0/dSSGgPEdXEhkQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-cluster/-/puppeteer-cluster-0.24.0.tgz",
+      "integrity": "sha512-zHPoNsrwkFLKFtgJJv2aC13EbMASQsE048uZd7CyikEXcl+sc1Nf6PMFb9kMoZI7/zMYxvuP658o2mw079ZZyQ==",
       "dev": true,
       "requires": {
-        "debug": "^4.3.3"
+        "debug": "^4.3.4"
       }
     },
     "puppeteer-core": {
-      "version": "19.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
-      "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
+      "version": "23.10.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.10.3.tgz",
+      "integrity": "sha512-7JG8klL2qHLyH8t2pOmM9zgykhaulUf7cxnmmqupjdwGfNMiGaYehQka20iUB9R/fwVyG8mFMZcsmw1FHrgKVw==",
       "dev": true,
       "requires": {
-        "@puppeteer/browsers": "0.5.0",
-        "chromium-bidi": "0.4.7",
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1107588",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.13.0"
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.8.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
       },
       "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        },
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "tar-fs": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^2.1.4"
-          }
-        },
-        "tar-stream": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-          "dev": true,
-          "requires": {
-            "bl": "^4.0.3",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -43948,6 +42387,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -43985,6 +42425,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -43999,13 +42440,6 @@
         "file-selector": "^0.6.0",
         "prop-types": "^15.8.1"
       }
-    },
-    "react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "dev": true,
-      "peer": true
     },
     "react-is": {
       "version": "17.0.2",
@@ -44060,8 +42494,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/react-ssr-prepass/-/react-ssr-prepass-1.5.0.tgz",
       "integrity": "sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "read": {
       "version": "1.0.5",
@@ -44831,6 +43264,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -45711,8 +44145,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "state-toggle": {
       "version": "1.0.3",
@@ -47431,224 +45864,6 @@
       "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==",
       "dev": true
     },
-    "victory-bar": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.2.tgz",
-      "integrity": "sha512-inqb9HLgxheidOAJw7jTMBBR18I7rCgtfH4WuCSMPPtZtUBAEDYFIJzAKzL/LrpC/sWi91fQC2tzmphTD3DS+Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2",
-        "victory-vendor": "37.3.2"
-      }
-    },
-    "victory-brush-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.2.tgz",
-      "integrity": "sha512-SZ4LuM8l3tpGkcnTaGGYREs8gz9E17/c9k3X8uObnXGpz9M3RXkL5hEP0ewtcCjbTr1nwRK3hB4tc1b5BTDj9w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-core": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.2.tgz",
-      "integrity": "sha512-ez/QW9OGltj0uo9EzsRrGEu/hS49dXoraQKblQJO4PEUkDZclV3Gy3CJ2cRW2qBM3ljTsVITiQvKt3urVj+RDw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.21",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "37.3.2"
-      }
-    },
-    "victory-create-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.2.tgz",
-      "integrity": "sha512-+hEHeTzeANX1knGOqbeykN1mPUy+zQ8A6LLUSiF8dER+DO2IcF/521LHjBSCRcyjUDik75shfhMc//wryxGBmQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "37.3.2",
-        "victory-core": "37.3.2",
-        "victory-cursor-container": "37.3.2",
-        "victory-selection-container": "37.3.2",
-        "victory-voronoi-container": "37.3.2",
-        "victory-zoom-container": "37.3.2"
-      }
-    },
-    "victory-cursor-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.2.tgz",
-      "integrity": "sha512-PpBIexoxV/D9S0JTwgI/AmGC5PEjVFbBg+dxbr0iBskXtIckIdXYg11Tejk4iatvUIuvXrJALMjH+y4Jhl+bGw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-group": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.2.tgz",
-      "integrity": "sha512-TB0ClboJsCR+ATIwUMgSdkdmau4XUiVaZtc5vehZYB7j50lv3SUtltc4qpztOrilsp1osoKHgUHpj7J8yhRtMw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2",
-        "victory-shared-events": "37.3.2"
-      }
-    },
-    "victory-legend": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.2.tgz",
-      "integrity": "sha512-NrXnStmdqWtfA2AkwOVVWGwXswN9C9TNnmUKzXY52BMWR4OQfIaeO0etRV3vSrv8yUD/rt+rm0UOAAI7pSb1Tw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-line": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.2.tgz",
-      "integrity": "sha512-ZA6A3te2A+egmSPG7jTRu/ZetRE66ggUix11yPaf+7DMZSnRw9f6KXduiUV+fz1otwefJ9pL6vMpXo2SIt9jFQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2",
-        "victory-vendor": "37.3.2"
-      }
-    },
-    "victory-pie": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.2.tgz",
-      "integrity": "sha512-et7Z9d1paoqXdSL8yNpdTadhhhpPgQTrqO5n7vISNJsjOmt0FTLe4/VeKIyugIhERirVkU5Va0CMlMInbNIysw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2",
-        "victory-vendor": "37.3.2"
-      }
-    },
-    "victory-scatter": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.2.tgz",
-      "integrity": "sha512-mFFIvFC5U+AX1uAgl19HI21L4Mf1rt2YlnjjzPFkJcgy0a2Fv6otjUd4qeqA6pAkVU4e/Dqj8ZZPV2PtfXNeyQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-selection-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.2.tgz",
-      "integrity": "sha512-g/26Xo4Rxco91GPjZ4jgIQDm95AT4zdG2RqXdQTWEgLbWi+Z/Tk1nodhr1jVjwIjZ6RNMeXcAtcVhFjIPLsWzQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-shared-events": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.2.tgz",
-      "integrity": "sha512-L/p/JzbP7O0x/DrWZicVByyiq0YMsDsvc2uinUCoI+XMAXbp7flxC2lbd7YBq41Sg13BHoPBiEoCXH4nKmo8hw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-stack": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.2.tgz",
-      "integrity": "sha512-lD8EyzYKTPyWam7h++6VfPxOw4Soj5kYjHqPlbjFjdxoGWYquHrcbHhJ4ra1p+Il9k6iDhy0lIU2DbLa2Ff0wA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2",
-        "victory-shared-events": "37.3.2"
-      }
-    },
-    "victory-tooltip": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.2.tgz",
-      "integrity": "sha512-UsEIGY5lqf3pOGr3ikB7oHw+QZtS+Qui/vqLPhoAL1YJ2bQ0WkIhVx2jLTlyCLIrj6aCvyvdePppApFF43E7Zg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      }
-    },
-    "victory-vendor": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.2.tgz",
-      "integrity": "sha512-2N8j0DIHocffTo2UeZbcd8fcB5+CrQq2KMOSbyTIzYuCVHP10XoS0R/ln7YOU5WoNS6/6L3GEdFWBaGYAAMErQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
-      }
-    },
-    "victory-voronoi-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.2.tgz",
-      "integrity": "sha512-Y5NiUcVa6SlAMl5yAI5pRRBRCUCDHJHYeUMCiccTOjA+G2B2pUJkJ5NKeFzMLt7hW1LQv0nnRs9ywpMdViF8nQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2",
-        "victory-tooltip": "37.3.2"
-      }
-    },
-    "victory-zoom-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.2.tgz",
-      "integrity": "sha512-znF3L6+LpQ8hN+7aW8RO+dsHPl1XsMAvf52IKc0OAXZzukIwx1+yW2/OLtHU7G0DzAl3Cxzt5BNd7jFLVXWQJw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      }
-    },
     "vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -47748,52 +45963,6 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true
     },
-    "webpack": {
-      "version": "5.95.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
-      }
-    },
     "webpack-bundle-analyzer": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.8.0.tgz",
@@ -47871,8 +46040,7 @@
           "version": "7.5.10",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
           "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -48346,8 +46514,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/preset-react": "^7.24.7",
         "@babel/preset-typescript": "^7.24.7",
         "@octokit/rest": "^20.1.1",
-        "@patternfly/documentation-framework": "6.0.6",
+        "@patternfly/documentation-framework": "^6.0.12",
         "@swc/core": "1.9.1",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -3298,7 +3298,6 @@
       "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "state-local": "^1.0.6"
       },
@@ -3312,7 +3311,6 @@
       "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0"
       },
@@ -3815,11 +3813,10 @@
       }
     },
     "node_modules/@patternfly/ast-helpers": {
-      "version": "1.4.0-alpha.125",
-      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.125.tgz",
-      "integrity": "sha512-WvN5CYFmTYOztt3wMidJq8xLdu6jhpHzjPvYxMN2wlh7v0QJEHaplvJGZH/E8ZUcri/ni2OoLVIe2KcuRwrxng==",
+      "version": "1.4.0-alpha.136",
+      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.136.tgz",
+      "integrity": "sha512-xB2sapSNa+TFRsD2aAym8SUOUtgKVCcH++lcWzdb62x4N4je6U9OYoODLB5CvvmOVSXulq3r34l9pojfEk3jPA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn": "^8.4.1",
         "acorn-class-fields": "^1.0.0",
@@ -3829,17 +3826,16 @@
       }
     },
     "node_modules/@patternfly/documentation-framework": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.0.6.tgz",
-      "integrity": "sha512-YXXzj7K2lmAZbvgTDSTd4AJTW6xpJ6G/C3jCMxGGMXevYJ1wGHQQnBVbGQvQcZPgIwU5nv3+FmnyfldJhRwQtw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.1.2.tgz",
+      "integrity": "sha512-RJh9v8B3BTs5ABqqCEnEpJXM7piQGavy607F7RX5CJhnw4dUSawy0qOByin0cdzNhFkxoe+DF2QN3enzrw1kOw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.3",
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.122",
+        "@patternfly/ast-helpers": "^1.4.0-alpha.136",
         "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
         "autoprefixer": "9.8.6",
         "babel-loader": "^9.1.3",
@@ -3851,7 +3847,7 @@
         "copy-webpack-plugin": "11.0.0",
         "css-loader": "6.7.3",
         "detab": "2.0.3",
-        "express": "4.21.0",
+        "express": "4.21.2",
         "file-loader": "6.2.0",
         "file-saver": "1.3.8",
         "fs-extra": "9.0.1",
@@ -3871,8 +3867,8 @@
         "postcss": "8.4.32",
         "postcss-loader": "7.1.0",
         "process": "^0.11.10",
-        "puppeteer": "19.11.1",
-        "puppeteer-cluster": "0.23.0",
+        "puppeteer": "^23.6.1",
+        "puppeteer-cluster": "^0.24.0",
         "react-docgen": "5.3.1",
         "react-ssr-prepass": "1.5.0",
         "remark-footnotes": "1.0.0",
@@ -3902,10 +3898,10 @@
         "pf-docs-framework": "scripts/cli/cli.js"
       },
       "peerDependencies": {
-        "@patternfly/patternfly": "^6.0.0",
-        "@patternfly/react-code-editor": "^6.0.0",
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-table": "^6.0.0",
+        "@patternfly/patternfly": "^6.1.0-prerelease.11",
+        "@patternfly/react-code-editor": "^6.1.0-prerelease.14",
+        "@patternfly/react-core": "^6.1.0-prerelease.14",
+        "@patternfly/react-table": "^6.1.0-prerelease.14",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
@@ -4353,51 +4349,6 @@
         "victory-voronoi-container": "^37.1.1"
       }
     },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/@puppeteer/browsers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
-      "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.3.7",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "semver": "^7.6.3",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/chromium-bidi": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
-      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0",
-        "zod": "3.23.8"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
     "node_modules/@patternfly/patternfly-a11y/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -4408,160 +4359,12 @@
         "node": ">=18"
       }
     },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/devtools-protocol": {
-      "version": "0.0.1367902",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
-      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/puppeteer": {
-      "version": "23.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.9.0.tgz",
-      "integrity": "sha512-WfB8jGwFV+qrD9dcJJVvWPFJBU6kxeu2wxJz9WooDGfM3vIiKLgzImEDBxUQnCBK/2cXB3d4dV6gs/LLpgfLDg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.4.1",
-        "chromium-bidi": "0.8.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1367902",
-        "puppeteer-core": "23.9.0",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/puppeteer-cluster": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-cluster/-/puppeteer-cluster-0.24.0.tgz",
-      "integrity": "sha512-zHPoNsrwkFLKFtgJJv2aC13EbMASQsE048uZd7CyikEXcl+sc1Nf6PMFb9kMoZI7/zMYxvuP658o2mw079ZZyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "puppeteer": ">=22.0.0"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/puppeteer-core": {
-      "version": "23.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.9.0.tgz",
-      "integrity": "sha512-hLVrav2HYMVdK0YILtfJwtnkBAwNOztUdR4aJ5YKDvgsbtagNr6urUJk9HyjRA9e+PaLI3jzJ0wM7A4jSZ7Qxw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.4.1",
-        "chromium-bidi": "0.8.0",
-        "debug": "^4.3.7",
-        "devtools-protocol": "0.0.1367902",
-        "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
-      }
-    },
-    "node_modules/@patternfly/patternfly-a11y/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/@patternfly/react-code-editor": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.0.0.tgz",
       "integrity": "sha512-TnI/NNkizzWTzdVZWmpyEPKXgsOoUeklk8Xlgtl7II/+5juLjlt0wXTMhL35F59Rzd0YohGs251zXAwJbn6vIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@patternfly/react-core": "^6.0.0",
@@ -4686,56 +4489,34 @@
       "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
-      "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=14.1.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4746,92 +4527,41 @@
         }
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@puppeteer/browsers/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@puppeteer/browsers/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+      "bin": {
+        "semver": "bin/semver.js"
       },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
       },
-      "engines": {
-        "node": ">=12"
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/@reach/router": {
@@ -5405,8 +5135,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -5501,87 +5230,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
-      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
-      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
-      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -6283,182 +5931,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
     "node_modules/@webpack-cli/configtest": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
@@ -6567,7 +6039,6 @@
       "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-1.0.0.tgz",
       "integrity": "sha512-l+1FokF34AeCXGBHkrXFmml9nOIRI+2yBnBpO5MaVAaTIJ96irWLtcCxX+7hAp6USHFCe+iyyBB4ZhxV807wmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn-private-class-elements": "^1.0.0"
       },
@@ -6599,17 +6070,6 @@
         "acorn": "^8"
       }
     },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -6625,7 +6085,6 @@
       "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-1.0.0.tgz",
       "integrity": "sha512-zYNcZtxKgVCg1brS39BEou86mIao1EV7eeREG+6WMwKbuYTeivRRs6S2XdWnboRde6G9wKh2w+WBydEyJsJ6mg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4.8.2"
       },
@@ -6638,7 +6097,6 @@
       "resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-1.0.0.tgz",
       "integrity": "sha512-XZJECjbmMOKvMHiNzbiPXuXpLAJfN3dAKtfIYbk1eHiWdsutlek+gS7ND4B8yJ3oqvHo1NxfafnezVmq7NXK0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn-private-class-elements": "^1.0.0"
       },
@@ -7139,7 +6597,6 @@
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
       "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "astring": "bin/astring"
       }
@@ -7655,7 +7112,6 @@
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -8584,13 +8040,14 @@
       "license": "MIT"
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
-      "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "mitt": "3.0.0"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -9468,11 +8925,10 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9793,16 +9249,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -10207,149 +9653,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -10368,7 +9671,6 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -10669,7 +9971,6 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -10684,7 +9985,6 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -10787,25 +10087,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/delaunator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/delaunay-find": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
-      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "delaunator": "^4.0.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -10900,11 +10181,10 @@
       "license": "MIT"
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1107588",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "dev": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -11274,7 +10554,6 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -11431,14 +10710,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -12671,18 +11942,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -12696,7 +11966,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -12711,6 +11981,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -13642,16 +12916,14 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.2.0"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">= 14"
@@ -15006,17 +14278,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -15049,7 +14310,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -15062,15 +14322,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/ip-regex": {
       "version": "4.3.0",
@@ -19755,11 +19013,10 @@
       }
     },
     "node_modules/mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -19780,14 +19037,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
-      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/moniker": {
       "version": "0.1.2",
@@ -19967,7 +19216,6 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -20037,27 +19285,6 @@
         "node": ">= 0.10.5"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-fetch-npm": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
@@ -20072,31 +19299,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -20733,34 +19935,29 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
+      "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.4"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -20770,7 +19967,6 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -20780,13 +19976,12 @@
       }
     },
     "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -20798,7 +19993,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -20809,7 +20003,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -20820,13 +20013,12 @@
       }
     },
     "node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -20839,7 +20031,6 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -21191,11 +20382,10 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -21777,7 +20967,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -21873,34 +21062,29 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
+        "pac-proxy-agent": "^7.1.0",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -21920,13 +21104,12 @@
       }
     },
     "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -21955,7 +21138,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -21966,7 +21148,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -21977,13 +21158,12 @@
       }
     },
     "node_modules/proxy-agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -22070,86 +21250,62 @@
       "license": "MIT"
     },
     "node_modules/puppeteer": {
-      "version": "19.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.11.1.tgz",
-      "integrity": "sha512-39olGaX2djYUdhaQQHDZ0T0GwEp+5f9UB9HmEP0qHfdQHIq0xGQZuAZ5TLnJIc/88SrPLpEflPC+xUqOTv3c5g==",
-      "deprecated": "< 22.8.2 is no longer supported",
+      "version": "23.10.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.10.3.tgz",
+      "integrity": "sha512-ODG+L9vCSPkQ1j+yDtNDdkSsWt2NXNrQO5C8MlwkYgE2hYnXdqVRbBpsHnoP7+EULJJKbWyR2Q4BdfohjQor3A==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "0.5.0",
-        "cosmiconfig": "8.1.3",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.11.1"
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.8.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.10.3",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer-cluster": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-cluster/-/puppeteer-cluster-0.23.0.tgz",
-      "integrity": "sha512-108terIWDzPrQopmoYSPd5yDoy3FGJ2dNnoGMkGYPs6xtkdhgaECwpfZkzaRToMQPZibUOz0/dSSGgPEdXEhkQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-cluster/-/puppeteer-cluster-0.24.0.tgz",
+      "integrity": "sha512-zHPoNsrwkFLKFtgJJv2aC13EbMASQsE048uZd7CyikEXcl+sc1Nf6PMFb9kMoZI7/zMYxvuP658o2mw079ZZyQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.3"
+        "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "puppeteer": ">=1.5.0"
+        "puppeteer": ">=22.0.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
-      "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
+      "version": "23.10.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.10.3.tgz",
+      "integrity": "sha512-7JG8klL2qHLyH8t2pOmM9zgykhaulUf7cxnmmqupjdwGfNMiGaYehQka20iUB9R/fwVyG8mFMZcsmw1FHrgKVw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "0.5.0",
-        "chromium-bidi": "0.4.7",
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1107588",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.13.0"
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.8.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
       },
       "engines": {
-        "node": ">=14.14.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -22160,111 +21316,36 @@
         }
       }
     },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/puppeteer/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
+      "dev": true
     },
     "node_modules/puppeteer/node_modules/cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "import-fresh": "^3.2.1",
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/puppeteer/node_modules/js-yaml": {
@@ -22272,20 +21353,12 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/puppeteer/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
@@ -22428,6 +21501,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -22476,6 +21550,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -22501,14 +21576,6 @@
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
       }
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -23726,6 +22793,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -24927,8 +23995,7 @@
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/state-toggle": {
       "version": "1.0.3",
@@ -26545,7 +25612,6 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -27189,8 +26255,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
       "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -27398,289 +26463,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/victory-bar": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.2.tgz",
-      "integrity": "sha512-inqb9HLgxheidOAJw7jTMBBR18I7rCgtfH4WuCSMPPtZtUBAEDYFIJzAKzL/LrpC/sWi91fQC2tzmphTD3DS+Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2",
-        "victory-vendor": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-brush-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.2.tgz",
-      "integrity": "sha512-SZ4LuM8l3tpGkcnTaGGYREs8gz9E17/c9k3X8uObnXGpz9M3RXkL5hEP0ewtcCjbTr1nwRK3hB4tc1b5BTDj9w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-core": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.2.tgz",
-      "integrity": "sha512-ez/QW9OGltj0uo9EzsRrGEu/hS49dXoraQKblQJO4PEUkDZclV3Gy3CJ2cRW2qBM3ljTsVITiQvKt3urVj+RDw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-create-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.2.tgz",
-      "integrity": "sha512-+hEHeTzeANX1knGOqbeykN1mPUy+zQ8A6LLUSiF8dER+DO2IcF/521LHjBSCRcyjUDik75shfhMc//wryxGBmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "37.3.2",
-        "victory-core": "37.3.2",
-        "victory-cursor-container": "37.3.2",
-        "victory-selection-container": "37.3.2",
-        "victory-voronoi-container": "37.3.2",
-        "victory-zoom-container": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-cursor-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.2.tgz",
-      "integrity": "sha512-PpBIexoxV/D9S0JTwgI/AmGC5PEjVFbBg+dxbr0iBskXtIckIdXYg11Tejk4iatvUIuvXrJALMjH+y4Jhl+bGw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-group": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.2.tgz",
-      "integrity": "sha512-TB0ClboJsCR+ATIwUMgSdkdmau4XUiVaZtc5vehZYB7j50lv3SUtltc4qpztOrilsp1osoKHgUHpj7J8yhRtMw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2",
-        "victory-shared-events": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-legend": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.2.tgz",
-      "integrity": "sha512-NrXnStmdqWtfA2AkwOVVWGwXswN9C9TNnmUKzXY52BMWR4OQfIaeO0etRV3vSrv8yUD/rt+rm0UOAAI7pSb1Tw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-line": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.2.tgz",
-      "integrity": "sha512-ZA6A3te2A+egmSPG7jTRu/ZetRE66ggUix11yPaf+7DMZSnRw9f6KXduiUV+fz1otwefJ9pL6vMpXo2SIt9jFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2",
-        "victory-vendor": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-pie": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.2.tgz",
-      "integrity": "sha512-et7Z9d1paoqXdSL8yNpdTadhhhpPgQTrqO5n7vISNJsjOmt0FTLe4/VeKIyugIhERirVkU5Va0CMlMInbNIysw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2",
-        "victory-vendor": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-scatter": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.2.tgz",
-      "integrity": "sha512-mFFIvFC5U+AX1uAgl19HI21L4Mf1rt2YlnjjzPFkJcgy0a2Fv6otjUd4qeqA6pAkVU4e/Dqj8ZZPV2PtfXNeyQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-selection-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.2.tgz",
-      "integrity": "sha512-g/26Xo4Rxco91GPjZ4jgIQDm95AT4zdG2RqXdQTWEgLbWi+Z/Tk1nodhr1jVjwIjZ6RNMeXcAtcVhFjIPLsWzQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-shared-events": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.2.tgz",
-      "integrity": "sha512-L/p/JzbP7O0x/DrWZicVByyiq0YMsDsvc2uinUCoI+XMAXbp7flxC2lbd7YBq41Sg13BHoPBiEoCXH4nKmo8hw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-stack": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.2.tgz",
-      "integrity": "sha512-lD8EyzYKTPyWam7h++6VfPxOw4Soj5kYjHqPlbjFjdxoGWYquHrcbHhJ4ra1p+Il9k6iDhy0lIU2DbLa2Ff0wA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2",
-        "victory-shared-events": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-tooltip": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.2.tgz",
-      "integrity": "sha512-UsEIGY5lqf3pOGr3ikB7oHw+QZtS+Qui/vqLPhoAL1YJ2bQ0WkIhVx2jLTlyCLIrj6aCvyvdePppApFF43E7Zg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.2.tgz",
-      "integrity": "sha512-2N8j0DIHocffTo2UeZbcd8fcB5+CrQq2KMOSbyTIzYuCVHP10XoS0R/ln7YOU5WoNS6/6L3GEdFWBaGYAAMErQ==",
-      "dev": true,
-      "license": "MIT AND ISC",
-      "peer": true,
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
-      }
-    },
-    "node_modules/victory-voronoi-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.2.tgz",
-      "integrity": "sha512-Y5NiUcVa6SlAMl5yAI5pRRBRCUCDHJHYeUMCiccTOjA+G2B2pUJkJ5NKeFzMLt7hW1LQv0nnRs9ywpMdViF8nQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.2",
-        "victory-tooltip": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-zoom-container": {
-      "version": "37.3.2",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.2.tgz",
-      "integrity": "sha512-znF3L6+LpQ8hN+7aW8RO+dsHPl1XsMAvf52IKc0OAXZzukIwx1+yW2/OLtHU7G0DzAl3Cxzt5BNd7jFLVXWQJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -27821,54 +26603,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/webpack": {
-      "version": "5.95.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "node_modules/webpack-bundle-analyzer": {
@@ -28267,26 +27001,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/websocket-driver": {
@@ -28896,7 +27610,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -28906,17 +27619,18 @@
       "version": "1.0.0-prerelease.0",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-component-groups": "6.0.0",
-        "@patternfly/react-core": "6.0.0",
-        "@patternfly/react-icons": "6.0.0",
-        "@patternfly/react-table": "6.0.0",
+        "@patternfly/react-component-groups": "^6.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
         "clsx": "^2.1.1",
         "react-jss": "^10.10.0"
       },
       "devDependencies": {
-        "@patternfly/documentation-framework": "6.0.8",
-        "@patternfly/patternfly": "6.0.0",
+        "@patternfly/documentation-framework": "^6.0.12",
+        "@patternfly/patternfly": "^6.0.0",
         "@patternfly/patternfly-a11y": "^5.0.0",
+        "@patternfly/react-code-editor": "^6.0.0",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "@types/react-router-dom": "^5.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/preset-react": "^7.24.7",
         "@babel/preset-typescript": "^7.24.7",
         "@octokit/rest": "^20.1.1",
-        "@patternfly/documentation-framework": "^6.0.12",
+        "@patternfly/documentation-framework": "^6.5.0",
         "@swc/core": "1.9.1",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -3813,9 +3813,9 @@
       }
     },
     "node_modules/@patternfly/ast-helpers": {
-      "version": "1.4.0-alpha.137",
-      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.137.tgz",
-      "integrity": "sha512-spdANBmCV2qMYzQDUlLa63HGm24p1vZbsN4QAsqREWHsOA+6WhME6Itc/TJimjuzwYlGvQj1Jv8q4LxyPGYKMw==",
+      "version": "1.4.0-alpha.141",
+      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.141.tgz",
+      "integrity": "sha512-gBwPtYbahatpIVcZaw2l4pzqndybWRVciapROyID7UEN6SfgOEQj8+28dmSEwJSbYlV+QpOFHaQGcGQzu6ZlYQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.4.1",
@@ -3826,16 +3826,16 @@
       }
     },
     "node_modules/@patternfly/documentation-framework": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.1.3.tgz",
-      "integrity": "sha512-s5VKxGw6WNjRVtYd+23NvgeuH2/U35zE7cD4+v97P5p7UB7r/nHBApIxOH1DJ4RklqcDVGcM8k1tkvBW8AWRTQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.5.0.tgz",
+      "integrity": "sha512-Zk8BSAPtCYGdNhRL/fQ6071XZV5Xjlhqq9V5aTYiq460WaEuGF5Ych2pwr9ZTAGKtvi0ncSjqS4thvITWusVMA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.3",
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.137",
+        "@patternfly/ast-helpers": "^1.4.0-alpha.141",
         "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
         "autoprefixer": "9.8.6",
         "babel-loader": "^9.1.3",
@@ -3898,10 +3898,10 @@
         "pf-docs-framework": "scripts/cli/cli.js"
       },
       "peerDependencies": {
-        "@patternfly/patternfly": "^6.1.0-prerelease.11",
-        "@patternfly/react-code-editor": "^6.1.0-prerelease.14",
-        "@patternfly/react-core": "^6.1.0-prerelease.14",
-        "@patternfly/react-table": "^6.1.0-prerelease.14",
+        "@patternfly/patternfly": "^6.1.0",
+        "@patternfly/react-code-editor": "^6.1.0",
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-table": "^6.1.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
@@ -4309,11 +4309,10 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.0.0.tgz",
-      "integrity": "sha512-Mn92Tt/4okSj1COGCJrgUgh390OOaFCWf0tL0WmigDNUecSHNn1D6Vhpd1hxHQBXvre9eWorzxV2b9yhSEl79Q==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.1.0.tgz",
+      "integrity": "sha512-w+QazL8NHKkg5j01eotblsswKxQQSYB0CN3yBXQL9ScpHdp/fK8M6TqWbKZNRpf+NqhMxcH/om8eR0N/fDCJqw==",
+      "dev": true
     },
     "node_modules/@patternfly/patternfly-a11y": {
       "version": "5.0.0",
@@ -4360,18 +4359,17 @@
       }
     },
     "node_modules/@patternfly/react-code-editor": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.0.0.tgz",
-      "integrity": "sha512-TnI/NNkizzWTzdVZWmpyEPKXgsOoUeklk8Xlgtl7II/+5juLjlt0wXTMhL35F59Rzd0YohGs251zXAwJbn6vIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.1.0.tgz",
+      "integrity": "sha512-ae04+DdkgXFn3wEzvNCncNa78ZK3Swh5ng8p7yqFrD6lhW69NoJf+DdQlHi8gM8Qy05DNnIemSbQWpWLpInyzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "react-dropzone": "14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "react-dropzone": "14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -4396,17 +4394,16 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0.tgz",
-      "integrity": "sha512-UKFj9+YzBY+FfEDsLONgOM4N0e8SPV/27/UzNRiJ0gpgqbw2POuXwLpjGSRTTIUuCaLaGGM5PeTSj7mMB73ykw==",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.1.0.tgz",
+      "integrity": "sha512-zj0lJPZxQanXKD8ae2kYnweT0kpp1CzpHYAkaBjTrw2k6ZMfr/UPlp0/ugCjWEokBqh79RUADLkKJJPce/yoSQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "@patternfly/react-tokens": "^6.0.0",
-        "focus-trap": "7.6.0",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
+        "focus-trap": "7.6.2",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -4418,33 +4415,30 @@
       "link": true
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0.tgz",
-      "integrity": "sha512-ZFrsBVKrAp0DZrPOss98OA/EVUL4F0frXhR1uBId9+3ZrRArdKTgYgmQUCeSzMbxnSlxpmm3a2L05XQ36VUVbw==",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.1.0.tgz",
+      "integrity": "sha512-V1w/j19YmOgvh72IRRf1p07k+u4M5+9P+o/IxunlF0fWzLDX4Hf+utBI11A8cRfUzpQN7eLw/vZIS3BLM8Ge3Q==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0.tgz",
-      "integrity": "sha512-fJFMB89sTRGlZTzTLmpRmthgOXqcN078scHMFJ3ttfi2D2btnem5oZrxmQ/gPZkZOxR+9MqwKDB6l3F5x1SqLQ==",
-      "license": "MIT"
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.1.0.tgz",
+      "integrity": "sha512-JQ3zIl5SFiSB0YWVYibcUwgZdsp6Wn8hkfZ7KhtCjHFccSDdJexPOXVV1O9f2h4PfxTlY3YntZ81ZsguBx/Q7A=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.0.0.tgz",
-      "integrity": "sha512-LvWMzjcQZHdFUpK8fjj5EAFrNxqB8/MFd7gUUZu7AgYt6rmS2im4xk6yb7h0K7cAhY085oPeRF9lkYSCgzlRDg==",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.1.0.tgz",
+      "integrity": "sha512-eC8mKkvFR0btfv6yEOvE+J4gBXU8ZGe9i2RSezBM+MJaXEQt/CKRjV+SAB5EeE3PyBYKG8yYDdsOoNmaPxxvSA==",
       "dependencies": {
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "@patternfly/react-tokens": "^6.0.0",
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "lodash": "^4.17.21",
-        "tslib": "^2.7.0"
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -4452,10 +4446,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0.tgz",
-      "integrity": "sha512-xd0ynDkiIW2rp8jz4TNvR4Dyaw9kSMkZdsuYcLlFXCVmvX//Mnl4rhBnid/2j2TaqK0NbkyTTPnPY/BU7SfLVQ==",
-      "license": "MIT"
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.1.0.tgz",
+      "integrity": "sha512-t1UcHbOa4txczTR5UlnG4XcAAdnDSfSlCaOddw/HTqRF59pn2ks2JUu9sfnFRZ8SiAAxKRiYdX5bT7Mf4R24+w=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5931,6 +5924,167 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
     "node_modules/@webpack-cli/configtest": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
@@ -6022,11 +6176,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6626,10 +6779,9 @@
       }
     },
     "node_modules/attr-accept": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.4.tgz",
-      "integrity": "sha512-2pA6xFIbdTUDCAwjN8nQwI+842VwzbDUXO2IYlpPXQIORgKnavorcr4Ce3rwh+zsNg9zK7QPsdvDj3Lum4WX4w==",
-      "license": "MIT",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
       "engines": {
         "node": ">=4"
       }
@@ -9252,11 +9404,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -10711,6 +10862,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
@@ -12142,16 +12300,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -12306,12 +12454,11 @@
       "license": "MIT"
     },
     "node_modules/file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
-      "license": "MIT",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">= 12"
@@ -12507,10 +12654,9 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
-      "license": "MIT",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -19038,6 +19184,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/moniker": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
@@ -19155,9 +19308,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -19165,7 +19318,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -21242,13 +21394,6 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/puppeteer": {
       "version": "23.10.3",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.10.3.tgz",
@@ -21501,7 +21646,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -21550,7 +21694,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -21561,13 +21704,12 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
-      "license": "MIT",
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
       "dependencies": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -22793,7 +22935,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -22973,11 +23114,10 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.3.tgz",
-      "integrity": "sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.4.tgz",
+      "integrity": "sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@zeit/schemas": "2.36.0",
         "ajv": "8.12.0",
@@ -22988,7 +23128,7 @@
         "clipboardy": "3.0.0",
         "compression": "1.7.4",
         "is-port-reachable": "4.0.0",
-        "serve-handler": "6.1.5",
+        "serve-handler": "6.1.6",
         "update-check": "1.5.4"
       },
       "bin": {
@@ -22999,19 +23139,17 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
-      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
       }
     },
@@ -23020,7 +23158,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -23030,7 +23167,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -23040,7 +23176,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
       "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -23050,7 +23185,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mime-db": "~1.33.0"
       },
@@ -23059,18 +23193,16 @@
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true
     },
     "node_modules/serve-handler/node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -24563,8 +24695,7 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT"
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -25374,10 +25505,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -26605,6 +26735,53 @@
         "node": ">=12"
       }
     },
+    "node_modules/webpack": {
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.8.0.tgz",
@@ -27001,6 +27178,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/websocket-driver": {
@@ -27627,7 +27823,7 @@
         "react-jss": "^10.10.0"
       },
       "devDependencies": {
-        "@patternfly/documentation-framework": "^6.0.12",
+        "@patternfly/documentation-framework": "^6.5.0",
         "@patternfly/patternfly": "^6.0.0",
         "@patternfly/patternfly-a11y": "^5.0.0",
         "@patternfly/react-code-editor": "^6.0.0",
@@ -28811,7 +29007,8 @@
           "version": "7.21.0-placeholder-for-preset-env.2",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
           "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -29888,7 +30085,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
       "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "13.2.2",
@@ -30053,9 +30251,9 @@
       "optional": true
     },
     "@patternfly/ast-helpers": {
-      "version": "1.4.0-alpha.137",
-      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.137.tgz",
-      "integrity": "sha512-spdANBmCV2qMYzQDUlLa63HGm24p1vZbsN4QAsqREWHsOA+6WhME6Itc/TJimjuzwYlGvQj1Jv8q4LxyPGYKMw==",
+      "version": "1.4.0-alpha.141",
+      "resolved": "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.141.tgz",
+      "integrity": "sha512-gBwPtYbahatpIVcZaw2l4pzqndybWRVciapROyID7UEN6SfgOEQj8+28dmSEwJSbYlV+QpOFHaQGcGQzu6ZlYQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.4.1",
@@ -30066,16 +30264,16 @@
       }
     },
     "@patternfly/documentation-framework": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.1.3.tgz",
-      "integrity": "sha512-s5VKxGw6WNjRVtYd+23NvgeuH2/U35zE7cD4+v97P5p7UB7r/nHBApIxOH1DJ4RklqcDVGcM8k1tkvBW8AWRTQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.5.0.tgz",
+      "integrity": "sha512-Zk8BSAPtCYGdNhRL/fQ6071XZV5Xjlhqq9V5aTYiq460WaEuGF5Ych2pwr9ZTAGKtvi0ncSjqS4thvITWusVMA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.24.3",
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.137",
+        "@patternfly/ast-helpers": "^1.4.0-alpha.141",
         "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
         "autoprefixer": "9.8.6",
         "babel-loader": "^9.1.3",
@@ -30437,9 +30635,9 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.0.0.tgz",
-      "integrity": "sha512-Mn92Tt/4okSj1COGCJrgUgh390OOaFCWf0tL0WmigDNUecSHNn1D6Vhpd1hxHQBXvre9eWorzxV2b9yhSEl79Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.1.0.tgz",
+      "integrity": "sha512-w+QazL8NHKkg5j01eotblsswKxQQSYB0CN3yBXQL9ScpHdp/fK8M6TqWbKZNRpf+NqhMxcH/om8eR0N/fDCJqw==",
       "dev": true
     },
     "@patternfly/patternfly-a11y": {
@@ -30467,17 +30665,17 @@
       }
     },
     "@patternfly/react-code-editor": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.0.0.tgz",
-      "integrity": "sha512-TnI/NNkizzWTzdVZWmpyEPKXgsOoUeklk8Xlgtl7II/+5juLjlt0wXTMhL35F59Rzd0YohGs251zXAwJbn6vIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.1.0.tgz",
+      "integrity": "sha512-ae04+DdkgXFn3wEzvNCncNa78ZK3Swh5ng8p7yqFrD6lhW69NoJf+DdQlHi8gM8Qy05DNnIemSbQWpWLpInyzw==",
       "dev": true,
       "requires": {
         "@monaco-editor/react": "^4.6.0",
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "react-dropzone": "14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "react-dropzone": "14.3.5",
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-component-groups": {
@@ -30493,22 +30691,22 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0.tgz",
-      "integrity": "sha512-UKFj9+YzBY+FfEDsLONgOM4N0e8SPV/27/UzNRiJ0gpgqbw2POuXwLpjGSRTTIUuCaLaGGM5PeTSj7mMB73ykw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.1.0.tgz",
+      "integrity": "sha512-zj0lJPZxQanXKD8ae2kYnweT0kpp1CzpHYAkaBjTrw2k6ZMfr/UPlp0/ugCjWEokBqh79RUADLkKJJPce/yoSQ==",
       "requires": {
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "@patternfly/react-tokens": "^6.0.0",
-        "focus-trap": "7.6.0",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
+        "focus-trap": "7.6.2",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-data-view": {
       "version": "file:packages/module",
       "requires": {
-        "@patternfly/documentation-framework": "^6.0.12",
+        "@patternfly/documentation-framework": "^6.5.0",
         "@patternfly/patternfly": "^6.0.0",
         "@patternfly/patternfly-a11y": "^5.0.0",
         "@patternfly/react-code-editor": "^6.0.0",
@@ -30530,32 +30728,33 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0.tgz",
-      "integrity": "sha512-ZFrsBVKrAp0DZrPOss98OA/EVUL4F0frXhR1uBId9+3ZrRArdKTgYgmQUCeSzMbxnSlxpmm3a2L05XQ36VUVbw=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.1.0.tgz",
+      "integrity": "sha512-V1w/j19YmOgvh72IRRf1p07k+u4M5+9P+o/IxunlF0fWzLDX4Hf+utBI11A8cRfUzpQN7eLw/vZIS3BLM8Ge3Q==",
+      "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0.tgz",
-      "integrity": "sha512-fJFMB89sTRGlZTzTLmpRmthgOXqcN078scHMFJ3ttfi2D2btnem5oZrxmQ/gPZkZOxR+9MqwKDB6l3F5x1SqLQ=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.1.0.tgz",
+      "integrity": "sha512-JQ3zIl5SFiSB0YWVYibcUwgZdsp6Wn8hkfZ7KhtCjHFccSDdJexPOXVV1O9f2h4PfxTlY3YntZ81ZsguBx/Q7A=="
     },
     "@patternfly/react-table": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.0.0.tgz",
-      "integrity": "sha512-LvWMzjcQZHdFUpK8fjj5EAFrNxqB8/MFd7gUUZu7AgYt6rmS2im4xk6yb7h0K7cAhY085oPeRF9lkYSCgzlRDg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.1.0.tgz",
+      "integrity": "sha512-eC8mKkvFR0btfv6yEOvE+J4gBXU8ZGe9i2RSezBM+MJaXEQt/CKRjV+SAB5EeE3PyBYKG8yYDdsOoNmaPxxvSA==",
       "requires": {
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "@patternfly/react-tokens": "^6.0.0",
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "lodash": "^4.17.21",
-        "tslib": "^2.7.0"
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0.tgz",
-      "integrity": "sha512-xd0ynDkiIW2rp8jz4TNvR4Dyaw9kSMkZdsuYcLlFXCVmvX//Mnl4rhBnid/2j2TaqK0NbkyTTPnPY/BU7SfLVQ=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.1.0.tgz",
+      "integrity": "sha512-t1UcHbOa4txczTR5UlnG4XcAAdnDSfSlCaOddw/HTqRF59pn2ks2JUu9sfnFRZ8SiAAxKRiYdX5bT7Mf4R24+w=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -30963,7 +31162,8 @@
       "version": "14.5.2",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
       "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -31595,23 +31795,187 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "peer": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "peer": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "peer": true
+    },
+    "@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "peer": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "peer": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
     "@webpack-cli/configtest": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -31648,9 +32012,9 @@
       }
     },
     "acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true
     },
     "acorn-class-fields": {
@@ -31676,19 +32040,22 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-private-class-elements": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-1.0.0.tgz",
       "integrity": "sha512-zYNcZtxKgVCg1brS39BEou86mIao1EV7eeREG+6WMwKbuYTeivRRs6S2XdWnboRde6G9wKh2w+WBydEyJsJ6mg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-static-class-features": {
       "version": "1.0.0",
@@ -31781,7 +32148,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -32049,9 +32417,9 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.4.tgz",
-      "integrity": "sha512-2pA6xFIbdTUDCAwjN8nQwI+842VwzbDUXO2IYlpPXQIORgKnavorcr4Ce3rwh+zsNg9zK7QPsdvDj3Lum4WX4w=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="
     },
     "autoprefixer": {
       "version": "9.8.6",
@@ -33870,9 +34238,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -34264,7 +34632,8 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -34894,6 +35263,13 @@
         "safe-array-concat": "^1.1.2"
       }
     },
+    "es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "peer": true
+    },
     "es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
@@ -35163,7 +35539,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-with-typescript": {
       "version": "23.0.0",
@@ -35179,7 +35556,8 @@
           "version": "17.0.0",
           "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
           "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -35479,7 +35857,8 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.37.1",
@@ -35533,7 +35912,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
       "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -35890,15 +36270,6 @@
       "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
       "dev": true
     },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.3.2"
-      }
-    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -36004,11 +36375,11 @@
       "dev": true
     },
     "file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
       "requires": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.7.0"
       }
     },
     "filesize": {
@@ -36150,9 +36521,9 @@
       }
     },
     "focus-trap": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
       "requires": {
         "tabbable": "^6.2.0"
       }
@@ -37111,7 +37482,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -38841,7 +39213,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -40651,6 +41024,13 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "dev": true,
+      "peer": true
+    },
     "moniker": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
@@ -40742,9 +41122,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true
     },
     "napi-build-utils": {
@@ -41798,7 +42178,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
       "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.5",
@@ -42214,12 +42595,6 @@
         }
       }
     },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
-    },
     "puppeteer": {
       "version": "23.10.3",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.10.3.tgz",
@@ -42387,7 +42762,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -42425,19 +42799,18 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       }
     },
     "react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
       "requires": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
         "prop-types": "^15.8.1"
       }
     },
@@ -42494,7 +42867,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/react-ssr-prepass/-/react-ssr-prepass-1.5.0.tgz",
       "integrity": "sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "read": {
       "version": "1.0.5",
@@ -43264,7 +43638,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -43405,9 +43778,9 @@
       }
     },
     "serve": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.3.tgz",
-      "integrity": "sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.4.tgz",
+      "integrity": "sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.36.0",
@@ -43419,7 +43792,7 @@
         "clipboardy": "3.0.0",
         "compression": "1.7.4",
         "is-port-reachable": "4.0.0",
-        "serve-handler": "6.1.5",
+        "serve-handler": "6.1.6",
         "update-check": "1.5.4"
       },
       "dependencies": {
@@ -43450,18 +43823,17 @@
       }
     },
     "serve-handler": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
-      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
       },
       "dependencies": {
@@ -43493,9 +43865,9 @@
           }
         },
         "path-to-regexp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+          "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
           "dev": true
         },
         "range-parser": {
@@ -45113,9 +45485,9 @@
       }
     },
     "tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -45963,6 +46335,52 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true
     },
+    "webpack": {
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "webpack-bundle-analyzer": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.8.0.tgz",
@@ -46040,7 +46458,8 @@
           "version": "7.5.10",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
           "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -46514,7 +46933,8 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@octokit/rest": "^20.1.1",
-    "@patternfly/documentation-framework": "^6.0.12",
+    "@patternfly/documentation-framework": "^6.5.0",
     "@swc/core": "1.9.1",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@octokit/rest": "^20.1.1",
-    "@patternfly/documentation-framework": "6.0.6",
+    "@patternfly/documentation-framework": "^6.0.12",
     "@swc/core": "1.9.1",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^17 || ^18"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "^6.0.12",
+    "@patternfly/documentation-framework": "^6.5.0",
     "@patternfly/patternfly": "^6.0.0",
     "@patternfly/react-code-editor": "^6.0.0",
     "@patternfly/patternfly-a11y": "^5.0.0",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -31,10 +31,10 @@
     "tag": "prerelease"
   },
   "dependencies": {
-    "@patternfly/react-component-groups": "6.0.0",
-    "@patternfly/react-core": "6.0.0",
-    "@patternfly/react-icons": "6.0.0",
-    "@patternfly/react-table": "6.0.0",
+    "@patternfly/react-component-groups": "^6.0.0",
+    "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-icons": "^6.0.0",
+    "@patternfly/react-table": "^6.0.0",
     "clsx": "^2.1.1",
     "react-jss": "^10.10.0"
   },
@@ -43,8 +43,9 @@
     "react-dom": "^17 || ^18"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "6.0.8",
-    "@patternfly/patternfly": "6.0.0",
+    "@patternfly/documentation-framework": "^6.0.12",
+    "@patternfly/patternfly": "^6.0.0",
+    "@patternfly/react-code-editor": "^6.0.0",
     "@patternfly/patternfly-a11y": "^5.0.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",

--- a/packages/module/patternfly-docs/generated/extensions/data-view/about-data-view/extensions.js
+++ b/packages/module/patternfly-docs/generated/extensions/data-view/about-data-view/extensions.js
@@ -23,7 +23,7 @@ pageData.examples = {
 
 const Component = () => (
   <React.Fragment>
-    <p {...{"className":"pf-v6-c-content--p ws-p "}}>
+    <p {...{"className":"pf-v6-c-content--p pf-m-editorial ws-p "}}>
       {`Data view lives in its own package `}
       <PatternflyThemeLink {...{"to":"https://www.npmjs.com/package/@patternfly/react-data-view","className":""}}>
         <code {...{"className":"ws-code "}}>
@@ -34,10 +34,10 @@ const Component = () => (
     <AutoLinkHeader {...{"id":"data-view","headingLevel":"h1","className":"ws-title ws-h1"}}>
       {`Data view`}
     </AutoLinkHeader>
-    <p {...{"className":"pf-v6-c-content--p ws-p "}}>
+    <p {...{"className":"pf-v6-c-content--p pf-m-editorial ws-p "}}>
       {`The data view extension contains implementation of the data view component allowing to display record data in a configured layout.`}
     </p>
-    <p {...{"className":"pf-v6-c-content--p ws-p "}}>
+    <p {...{"className":"pf-v6-c-content--p pf-m-editorial ws-p "}}>
       {`If you notice a bug or have a suggestion for the data view, feel free to file an issue in our `}
       <PatternflyThemeLink {...{"to":"https://github.com/patternfly/react-data-view/issues","className":""}}>
         {`GitHub repository`}

--- a/packages/module/patternfly-docs/generated/index.js
+++ b/packages/module/patternfly-docs/generated/index.js
@@ -25,8 +25,8 @@ module.exports = {
   '/extensions/data-view/functionality/react': {
     id: "Functionality",
     title: "Functionality",
-    toc: [[{"text":"Toolbar usage"},{"text":"Pagination state"},{"text":"Pagination example"},{"text":"Toolbar usage","id":"toolbar-usage-0"},{"text":"Selection state"},{"text":"Selection example"}]],
-    examples: ["Pagination example","Selection example"],
+    toc: [[{"text":"Toolbar usage"},{"text":"Pagination state"},{"text":"Pagination example"},{"text":"Toolbar usage","id":"toolbar-usage-0"},{"text":"Selection state"},{"text":"Selection example"},{"text":"Toolbar usage","id":"toolbar-usage-1"},{"text":"Filters state"},{"text":"Filtering example"},{"text":"Sort state"},{"text":"Sorting example"}]],
+    examples: ["Pagination example","Selection example","Filtering example","Sorting example"],
     section: "extensions",
     subsection: "Data view",
     source: "react",


### PR DESCRIPTION
This should (hopefully) fix the build for the outstanding dependencies 🤞🏻 

when running `npm install` locally, I think you'll need to add `npm install --legacy-peer-deps` until the next PF release and we can bump to a version of the docs-framework which will be more compatible and not require that flag. I'll try to keep an eye on that.