### PR TITLE
chore: remove conflicting packageManager entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,5 @@
     "ts-jest": "29.1.5",
     "wait-on": "^7.2.0",
     "whatwg-fetch": "^3.6.20"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
Remove conflicting `packageManager` entry

part of [RHCLOUD-36357](https://issues.redhat.com/browse/RHCLOUD-36357)