### PR TITLE
fix(filters): properly initialize array search param

### DIFF
--- a/packages/module/src/Hooks/filters.test.tsx
+++ b/packages/module/src/Hooks/filters.test.tsx
@@ -53,6 +53,33 @@ describe('useDataViewFilters', () => {
     expect(setSearchParams).toHaveBeenCalled();
   });
 
+  it('should sync with URL search params with non array value', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.set('test', 'foo');
+    const setSearchParams = jest.fn();
+    const props: UseDataViewFiltersProps<{ test: string }> = {
+      initialFilters: { test: '' },
+      searchParams,
+      setSearchParams,
+    };
+    const { result } = renderHook(() => useDataViewFilters(props));
+    expect(result.current.filters).toEqual({ test: 'foo' });
+  })  
+  it('should sync with URL search params with array value', () => {
+
+    const searchParams = new URLSearchParams();
+    searchParams.append('test', 'foo');
+    searchParams.append('test', 'bar');
+    const setSearchParams = jest.fn();
+    const props: UseDataViewFiltersProps<{ test: string[] }> = {
+      initialFilters: { test: [] },
+      searchParams,
+      setSearchParams,
+    };
+    const { result } = renderHook(() => useDataViewFilters(props));
+    expect(result.current.filters).toEqual({ test: [ 'foo', 'bar' ] });
+  })  
+
   it('should reset filters to default values when clearAllFilters is called', () => {
     const { result } = renderHook(() => useDataViewFilters({ initialFilters }));
     act(() => result.current.clearAllFilters());

--- a/packages/module/src/Hooks/filters.ts
+++ b/packages/module/src/Hooks/filters.ts
@@ -18,8 +18,8 @@ export const useDataViewFilters = <T extends object>({
 
   const getInitialFilters = useCallback((): T => isUrlSyncEnabled
     ? Object.keys(initialFilters).reduce((loadedFilters, key) => {
-      const urlValue = searchParams?.get(key);
       const isArrayFilter = Array.isArray(initialFilters[key]);
+      const urlValue = isArrayFilter ? searchParams?.getAll(key) : searchParams?.get(key);
 
       // eslint-disable-next-line no-nested-ternary
       loadedFilters[key] = urlValue


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-39151

Array search parameters were not properly extracted from URL during state initialization