### PR TITLE
fix(docs): single selection

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/DataView/PredefinedLayoutFullExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/DataView/PredefinedLayoutFullExample.tsx
@@ -152,7 +152,7 @@ const RepositoriesTable: React.FunctionComponent<RepositoriesTableProps> = ({ se
   const pagination = useDataViewPagination({ perPage: 5 });
   const { page, perPage } = pagination;
 
-  const selection = useDataViewSelection({ matchOption: (a, b) => a[0] === b[0] });
+  const selection = useDataViewSelection({ matchOption: (a, b) => a.row[0] === b.row[0] });
   const { selected, onSelect, isSelected } = selection;
   
   const { trigger } = useDataViewEventsContext();


### PR DESCRIPTION
In the [`Data view`](https://www.patternfly.org/extensions/data-view/overview/#dataview) documentation clicking on a checkbox selects all items
![image](https://github.com/user-attachments/assets/4b9a6842-7413-488f-8b5a-74fb6d7c9c34)
