### PR TITLE
fix: fix bottom pagination on small viewports

### DIFF
--- a/cypress/component/DataView.cy.tsx
+++ b/cypress/component/DataView.cy.tsx
@@ -57,7 +57,7 @@ describe('DataView', () => {
           } 
         />
         <DataViewTable aria-label='Repositories table' ouiaId={ouiaId} columns={columns} rows={rows} />
-        <DataViewToolbar ouiaId="DataViewFooter" pagination={<Pagination isCompact {...PAGINATION} />} />
+        <DataViewToolbar ouiaId="DataViewFooter" pagination={<Pagination isCompact variant="bottom" {...PAGINATION} />} />
       </DataView>
     );
     cy.get('[data-ouia-component-id="DataViewToolbar-pagination"]').should('exist');

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/DataView/PredefinedLayoutFullExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/DataView/PredefinedLayoutFullExample.tsx
@@ -244,7 +244,8 @@ const RepositoriesTable: FunctionComponent<RepositoriesTableProps> = ({ selected
         ouiaId='LayoutExampleFooter'
         pagination={
           <Pagination 
-            isCompact  
+            isCompact
+            variant="bottom"
             perPageOptions={perPageOptions} 
             itemCount={repositories.length} 
             {...pagination} 

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Toolbar/FiltersExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Toolbar/FiltersExample.tsx
@@ -89,7 +89,8 @@ const MyTable: React.FunctionComponent = () => {
         ouiaId='LayoutExampleFooter'
         pagination={
           <Pagination 
-            isCompact  
+            isCompact
+            variant="bottom"
             perPageOptions={perPageOptions} 
             itemCount={filteredData.length} 
             {...pagination} 

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Toolbar/PaginationExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Toolbar/PaginationExample.tsx
@@ -44,7 +44,7 @@ const MyTable: React.FunctionComponent = () => {
     <DataView>
       <DataViewToolbar ouiaId='DataViewHeader' pagination={<Pagination perPageOptions={perPageOptions} itemCount={repositories.length} {...pagination} />} />
       <DataViewTable aria-label='Repositories table' ouiaId={ouiaId} columns={columns} rows={pageRows} />
-      <DataViewToolbar ouiaId='DataViewFooter' pagination={<Pagination isCompact perPageOptions={perPageOptions} itemCount={repositories.length} {...pagination} />} />
+      <DataViewToolbar ouiaId='DataViewFooter' pagination={<Pagination isCompact variant="bottom" perPageOptions={perPageOptions} itemCount={repositories.length} {...pagination} />} />
     </DataView>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Toolbar/TreeFilterExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Toolbar/TreeFilterExample.tsx
@@ -234,7 +234,7 @@ const MyTable: React.FunctionComponent = () => {
       <DataViewToolbar
         ouiaId="TreeFilterExampleFooter"
         pagination={
-          <Pagination isCompact perPageOptions={perPageOptions} itemCount={filteredData.length} {...pagination} />
+          <Pagination isCompact variant="bottom" perPageOptions={perPageOptions} itemCount={filteredData.length} {...pagination} />
         }
       />
     </DataView>

--- a/packages/module/src/DataViewToolbar/DataViewToolbar.tsx
+++ b/packages/module/src/DataViewToolbar/DataViewToolbar.tsx
@@ -1,5 +1,6 @@
 import { FC, PropsWithChildren, useRef } from 'react';
 import { Button, Toolbar, ToolbarContent, ToolbarItem, ToolbarItemVariant, ToolbarProps } from '@patternfly/react-core';
+import { createUseStyles } from 'react-jss';
 
 /** extends ToolbarProps */
 export interface DataViewToolbarProps extends Omit<PropsWithChildren<ToolbarProps>, 'ref'> {
@@ -21,7 +22,19 @@ export interface DataViewToolbarProps extends Omit<PropsWithChildren<ToolbarProp
   customLabelGroupContent?: React.ReactNode;
 }
 
+const useStyles = createUseStyles({
+  dataViewToolbarPagination: {
+    flexBasis: '100%',
+    width: '100%'
+  },
+  dataViewToolbarPaginationWrapper: {
+    flexBasis: '100%',
+    width: '100%'
+  }
+});
+
 export const DataViewToolbar: FC<DataViewToolbarProps> = ({ className, ouiaId = 'DataViewToolbar', bulkSelect, actions, toggleGroup, pagination, filters, customLabelGroupContent, clearAllFilters, children, ...props }: DataViewToolbarProps) => {
+  const classes = useStyles();
   const defaultClearFilters = useRef(
     <ToolbarItem>
       <Button ouiaId={`${ouiaId}-clear-all-filters`} variant="link" onClick={clearAllFilters} isInline>
@@ -53,8 +66,10 @@ export const DataViewToolbar: FC<DataViewToolbarProps> = ({ className, ouiaId = 
           </ToolbarItem>
         )}
         {pagination && (
-          <ToolbarItem variant={ToolbarItemVariant.pagination} data-ouia-component-id={`${ouiaId}-pagination`}>
-            {pagination}
+          <ToolbarItem variant={ToolbarItemVariant.pagination} data-ouia-component-id={`${ouiaId}-pagination`} className={classes.dataViewToolbarPagination}>
+            <div className={classes.dataViewToolbarPaginationWrapper}>
+              {pagination}
+            </div>
           </ToolbarItem>
         )}
         {children}

--- a/packages/module/src/DataViewToolbar/__snapshots__/DataViewToolbar.test.tsx.snap
+++ b/packages/module/src/DataViewToolbar/__snapshots__/DataViewToolbar.test.tsx.snap
@@ -19,8 +19,295 @@ exports[`DataViewToolbar component should render correctly 1`] = `
             class="pf-v6-c-toolbar__content-section"
           >
             <div
-              class="pf-v6-c-toolbar__item pf-m-pagination"
+              class="pf-v6-c-toolbar__item pf-m-pagination dataViewToolbarPagination-0-2-1"
               data-ouia-component-id="DataViewToolbar-pagination"
+            >
+              <div
+                class="dataViewToolbarPaginationWrapper-0-2-2"
+              >
+                <div
+                  class="pf-v6-c-pagination"
+                  data-ouia-component-id="OUIA-Generated-Pagination-top-1"
+                  data-ouia-component-type="PF6/Pagination"
+                  data-ouia-safe="true"
+                  id="options-menu-top-pagination"
+                  style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                >
+                  <div
+                    class="pf-v6-c-pagination__total-items"
+                  >
+                    <b>
+                      1
+                       - 
+                      10
+                    </b>
+                     
+                    of
+                     
+                    <b>
+                      0
+                    </b>
+                     
+                  </div>
+                  <div
+                    class="pf-v6-c-pagination__page-menu"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
+                      data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-1"
+                      data-ouia-component-type="PF6/MenuToggle"
+                      data-ouia-safe="true"
+                      id="options-menu-top-toggle"
+                      type="button"
+                    >
+                      <span
+                        class="pf-v6-c-menu-toggle__text"
+                      >
+                        <b>
+                          1
+                           - 
+                          10
+                        </b>
+                         
+                        of
+                         
+                        <b>
+                          0
+                        </b>
+                         
+                      </span>
+                      <span
+                        class="pf-v6-c-menu-toggle__controls"
+                      >
+                        <span
+                          class="pf-v6-c-menu-toggle__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                  <nav
+                    aria-label="Pagination"
+                    class="pf-v6-c-pagination__nav"
+                  >
+                    <div
+                      class="pf-v6-c-pagination__nav-control pf-m-first"
+                    >
+                      <button
+                        aria-label="Go to first page"
+                        class="pf-v6-c-button pf-m-plain"
+                        data-action="first"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        disabled=""
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 448 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-pagination__nav-control"
+                    >
+                      <button
+                        aria-label="Go to previous page"
+                        class="pf-v6-c-button pf-m-plain"
+                        data-action="previous"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        disabled=""
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-pagination__nav-page-select"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="Current page"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          max="2"
+                          min="1"
+                          type="number"
+                          value="1"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-pagination__nav-control"
+                    >
+                      <button
+                        aria-label="Go to next page"
+                        class="pf-v6-c-button pf-m-plain"
+                        data-action="next"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-pagination__nav-control pf-m-last"
+                    >
+                      <button
+                        aria-label="Go to last page"
+                        class="pf-v6-c-button pf-m-plain"
+                        data-action="last"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 448 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                  </nav>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+          <div
+            class="pf-v6-c-toolbar__group pf-m-action-group-inline"
+          >
+            <div
+              class="pf-v6-c-toolbar__item"
+            >
+              <button
+                class="pf-v6-c-button pf-m-link pf-m-inline"
+                data-ouia-component-id="DataViewToolbar-clear-all-filters"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__text"
+                >
+                  Clear filters
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="pf-v6-c-toolbar"
+      data-ouia-component-id="DataViewToolbar"
+      data-ouia-component-type="PF6/Toolbar"
+      data-ouia-safe="true"
+      id="pf-random-id-0"
+    >
+      <div
+        class="pf-v6-c-toolbar__content"
+      >
+        <div
+          class="pf-v6-c-toolbar__content-section"
+        >
+          <div
+            class="pf-v6-c-toolbar__item pf-m-pagination dataViewToolbarPagination-0-2-1"
+            data-ouia-component-id="DataViewToolbar-pagination"
+          >
+            <div
+              class="dataViewToolbarPaginationWrapper-0-2-2"
             >
               <div
                 class="pf-v6-c-pagination"
@@ -249,285 +536,6 @@ exports[`DataViewToolbar component should render correctly 1`] = `
                   </div>
                 </nav>
               </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pf-v6-c-toolbar__content pf-m-hidden"
-          hidden=""
-        >
-          <div
-            class="pf-v6-c-toolbar__group"
-          />
-          <div
-            class="pf-v6-c-toolbar__group pf-m-action-group-inline"
-          >
-            <div
-              class="pf-v6-c-toolbar__item"
-            >
-              <button
-                class="pf-v6-c-button pf-m-link pf-m-inline"
-                data-ouia-component-id="DataViewToolbar-clear-all-filters"
-                data-ouia-component-type="PF6/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-button__text"
-                >
-                  Clear filters
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div
-      class="pf-v6-c-toolbar"
-      data-ouia-component-id="DataViewToolbar"
-      data-ouia-component-type="PF6/Toolbar"
-      data-ouia-safe="true"
-      id="pf-random-id-0"
-    >
-      <div
-        class="pf-v6-c-toolbar__content"
-      >
-        <div
-          class="pf-v6-c-toolbar__content-section"
-        >
-          <div
-            class="pf-v6-c-toolbar__item pf-m-pagination"
-            data-ouia-component-id="DataViewToolbar-pagination"
-          >
-            <div
-              class="pf-v6-c-pagination"
-              data-ouia-component-id="OUIA-Generated-Pagination-top-1"
-              data-ouia-component-type="PF6/Pagination"
-              data-ouia-safe="true"
-              id="options-menu-top-pagination"
-              style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-            >
-              <div
-                class="pf-v6-c-pagination__total-items"
-              >
-                <b>
-                  1
-                   - 
-                  10
-                </b>
-                 
-                of
-                 
-                <b>
-                  0
-                </b>
-                 
-              </div>
-              <div
-                class="pf-v6-c-pagination__page-menu"
-              >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
-                  data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-1"
-                  data-ouia-component-type="PF6/MenuToggle"
-                  data-ouia-safe="true"
-                  id="options-menu-top-toggle"
-                  type="button"
-                >
-                  <span
-                    class="pf-v6-c-menu-toggle__text"
-                  >
-                    <b>
-                      1
-                       - 
-                      10
-                    </b>
-                     
-                    of
-                     
-                    <b>
-                      0
-                    </b>
-                     
-                  </span>
-                  <span
-                    class="pf-v6-c-menu-toggle__controls"
-                  >
-                    <span
-                      class="pf-v6-c-menu-toggle__toggle-icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 320 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </button>
-              </div>
-              <nav
-                aria-label="Pagination"
-                class="pf-v6-c-pagination__nav"
-              >
-                <div
-                  class="pf-v6-c-pagination__nav-control pf-m-first"
-                >
-                  <button
-                    aria-label="Go to first page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="first"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 448 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-c-pagination__nav-control"
-                >
-                  <button
-                    aria-label="Go to previous page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="previous"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-c-pagination__nav-page-select"
-                >
-                  <span
-                    class="pf-v6-c-form-control"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="Current page"
-                      data-ouia-component-id="OUIA-Generated-TextInputBase-1"
-                      data-ouia-component-type="PF6/TextInput"
-                      data-ouia-safe="true"
-                      max="2"
-                      min="1"
-                      type="number"
-                      value="1"
-                    />
-                  </span>
-                </div>
-                <div
-                  class="pf-v6-c-pagination__nav-control"
-                >
-                  <button
-                    aria-label="Go to next page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="next"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-c-pagination__nav-control pf-m-last"
-                >
-                  <button
-                    aria-label="Go to last page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="last"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 448 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-              </nav>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Fix Footer Pagination on Small Viewports [RHCLOUD-44745](https://issues.redhat.com/browse/RHCLOUD-44745)
https://github.com/patternfly/react-data-view/issues/510
https://github.com/patternfly/react-data-view/issues/516

# Before
<img width="700" height="252" alt="image" src="https://github.com/user-attachments/assets/aa6782aa-2a00-4af9-9d0a-cf5f496bdb87" />

# After
<img width="700" height="252" alt="image" src="https://github.com/user-attachments/assets/9cef1ea5-9612-43ee-b8ca-4e1a89299bb9" />

- Use `variant="bottom"` for DataViewToolbar footer to fix pagination on small screens
- Styling fixes to ensure footer toolbar displays properly
- Updated examples to show the above