### PR TITLE
feat(DataViewTableBasic): Make select column sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ When adding/making changes to a component, always make sure your code is tested:
 
 ## Testing and Linting
 - run `npm run test` to run the unit tests
-- run `cypress:run:ci:cp` to run component tests
-- run `cypress:run:ci:e2e` to run E2E tests
+- run `npm run cypress:run:ci:cp` to run component tests
+- run `npm run cypress:run:ci:e2e` to run E2E tests
 - run `npm run lint` to run the linter
 
 ## A11y testing

--- a/cypress/component/DataViewTableBasic.cy.tsx
+++ b/cypress/component/DataViewTableBasic.cy.tsx
@@ -23,6 +23,30 @@ const rows = repositories.map(item => Object.values(item));
 
 const columns = [ 'Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit' ];
 
+const stickyColumns = [
+  { cell: 'Repositories', props: { isStickyColumn: true, hasRightBorder: true } },
+  'Branches',
+  'Pull requests',
+  'Workspaces',
+  'Last commit',
+];
+
+const stickyRows = [
+  { name: 'Repository one', branches: 'Branch one', prs: 'Pull request one', workspaces: 'Workspace one', lastCommit: 'Timestamp one' },
+].map(item => [
+  { cell: item.name, props: { isStickyColumn: true, hasRightBorder: true } },
+  item.branches,
+  item.prs,
+  item.workspaces,
+  item.lastCommit,
+]);
+
+const selection = {
+  onSelect: () => undefined,
+  isSelected: () => false,
+  isSelectDisabled: () => false,
+};
+
 describe('DataViewTableBasic', () => {
 
   it('renders a basic data view table', () => {
@@ -100,6 +124,25 @@ describe('DataViewTableBasic', () => {
 
     cy.get('[data-ouia-component-id="data-tr-loading"]').should('be.visible');
     cy.get('[data-ouia-component-id="data-tr-loading"]').contains('Data is loading');
+  });
+
+  it('applies sticky column styling to the selection and first data column when isSticky and the first column is sticky', () => {
+    const ouiaId = 'data-sticky-select';
+
+    cy.mount(
+      <DataView selection={selection}>
+        <DataViewTableBasic
+          aria-label="Sticky selectable table"
+          ouiaId={ouiaId}
+          columns={stickyColumns}
+          rows={stickyRows}
+          isSticky
+        />
+      </DataView>
+    );
+
+    cy.get('thead tr th.pf-v6-c-table__sticky-cell').should('have.length', 2);
+    cy.get('tbody tr').first().find('td.pf-v6-c-table__sticky-cell').should('have.length', 2);
   });
 
 });

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/DataViewTableInteractiveExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/DataViewTableInteractiveExample.tsx
@@ -81,12 +81,13 @@ export const InteractiveExample: FunctionComponent = () => {
   const rows: DataViewTr[] = repositories.map(({ id, name, branches, prs, workspaces, lastCommit, contributors, stars, forks }) => [
     {
       id,
-      cell: workspaces,
+      cell: isSticky ? null : workspaces,
       props: {
-        favorites: { isFavorited: true }
+        favorites: { isFavorited: true },
+        ...(isSticky ? { isStickyColumn: true } : {}),
       }
     },
-    { cell: <Button href='#' variant='link' isInline>{name}</Button>, props: { isStickyColumn: isSticky, hasRightBorder: true, hasLeftBorder: true, modifier: "nowrap" } },
+    { cell: <Button href='#' variant='link' isInline>{name}</Button>, props: { isStickyColumn: isSticky, hasRightBorder: isSticky, modifier: "nowrap" } },
     { cell: branches, props: { modifier: "nowrap" } },
     { cell: prs, props: { modifier: "nowrap" } },
     { cell: workspaces, props: { modifier: "nowrap" } },
@@ -97,8 +98,8 @@ export const InteractiveExample: FunctionComponent = () => {
   ]);
 
   const columns: DataViewTh[] = [
-    null,
-    { cell: 'Repositories', props: { isStickyColumn: isSticky, modifier: 'fitContent', hasRightBorder: true, hasLeftBorder: true } },
+    isSticky ? { cell: '', props: { isStickyColumn: true, stickyMinWidth: '3rem' } } : null,
+    { cell: 'Repositories', props: { isStickyColumn: isSticky, modifier: 'nowrap', hasRightBorder: isSticky } },
     { cell: <>Branches<ExclamationCircleIcon className='pf-v6-u-ml-sm' color="var(--pf-t--global--color--status--danger--default)"/></>, props: { width: 20 } },
     { cell: 'Pull requests', props: { width: 20 } },
     { cell: 'Workspaces', props: { info: { tooltip: 'More information' }, width: 20 } },

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/DataViewTableStickyExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/DataViewTableStickyExample.tsx
@@ -50,8 +50,8 @@ const rowActions = [
 ];
 
 const rows: DataViewTr[] = repositories.map(({ id, name, branches, prs, workspaces, lastCommit, contributors, stars, forks }) => [
-  { id, cell: workspaces, props: { favorites: { isFavorited: true } } },
-  { cell: <Button href='#' variant='link' isInline>{name}</Button>, props: { isStickyColumn: true, hasRightBorder: true, hasLeftBorder: true, modifier: "nowrap" } },
+  { id, cell: null, props: { favorites: { isFavorited: true }, isStickyColumn: true } },
+  { cell: <Button href='#' variant='link' isInline>{name}</Button>, props: { isStickyColumn: true, hasRightBorder: true, modifier: "nowrap" } },
   { cell: branches, props: { modifier: "nowrap" } },
   { cell: prs, props: { modifier: "nowrap" } },
   { cell: workspaces, props: { modifier: "nowrap" } },
@@ -63,8 +63,8 @@ const rows: DataViewTr[] = repositories.map(({ id, name, branches, prs, workspac
 ]);
 
 const columns: DataViewTh[] = [
-  null,
-  { cell: 'Repositories', props: { isStickyColumn: true, modifier: 'fitContent', hasRightBorder: true, hasLeftBorder: true } },
+  { cell: '', props: { isStickyColumn: true, stickyMinWidth: '4rem' } },
+  { cell: 'Repositories', props: { isStickyColumn: true, stickyMinWidth: '150px', hasRightBorder: true } },
   { cell: <>Branches<ExclamationCircleIcon className='pf-v6-u-ml-sm' color="var(--pf-t--global--color--status--danger--default)"/></>, props: { width: 20 } },
   { cell: 'Pull requests', props: { width: 20 } },
   { cell: 'Workspaces', props: { info: { tooltip: 'More information' }, width: 20 } },

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/Table.md
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/Table.md
@@ -19,7 +19,8 @@ propComponents:
     'DataViewTrTree',
     'DataViewTrObject',
     'DataViewTh',
-    'DataViewThResizableProps'
+    'DataViewThResizableProps',
+    'DataViewTableHead'
   ]
 sourceLink: https://github.com/patternfly/react-data-view/blob/main/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/Table.md
 ---
@@ -104,6 +105,8 @@ When sticky headers and columns are enabled:
 - Columns marked with `isStickyColumn: true` remain visible when scrolling horizontally
 - The table is wrapped in `OuterScrollContainer` and `InnerScrollContainer` components to enable sticky behavior
 - Sticky columns can have additional styling like borders using `hasRightBorder` or `hasLeftBorder` props
+
+When **row selection** is enabled (via the `DataView` `selection` prop) and the first column in the `columns` array is a sticky column (`isStickyColumn: true` in that column’s `props`), the row-selection checkbox column is included in the same sticky group as that first data column. The first data column’s `stickyLeftOffset` is aligned so it sits to the right of the selection column. This requires the first **defined** column in `columns` to be the sticky one; a leading `null` placeholder in `columns` is not treated as a sticky first column for this behavior.
 
 ### Sticky header and columns example
 

--- a/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/Table.md
+++ b/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/Table.md
@@ -19,7 +19,8 @@ propComponents:
     'DataViewTrTree',
     'DataViewTrObject',
     'DataViewTh',
-    'DataViewThResizableProps'
+    'DataViewThResizableProps',
+    'DataViewTableHead'
   ]
 sourceLink: https://github.com/patternfly/react-data-view/blob/main/packages/module/patternfly-docs/content/extensions/data-view/examples/Table/Table.md
 ---
@@ -103,7 +104,11 @@ When sticky headers and columns are enabled:
 - The table header remains visible when scrolling vertically
 - Columns marked with `isStickyColumn: true` remain visible when scrolling horizontally
 - The table is wrapped in `OuterScrollContainer` and `InnerScrollContainer` components to enable sticky behavior
-- Sticky columns can have additional styling like borders using `hasRightBorder` or `hasLeftBorder` props
+- Sticky columns can use `hasRightBorder` on the **last** column in a locked group to draw a single divider before scrollable columns. Do not set `hasRightBorder` or `hasLeftBorder` on earlier columns in the group (for example, the selection checkbox column or a leading favorites column).
+
+When **row selection** is enabled (via the `DataView` `selection` prop) and a column in the `columns` array is marked `isStickyColumn: true`, the row-selection checkbox column is included in the same sticky group. The checkbox column stays sticky without a right border; the first sticky data column’s `stickyLeftOffset` is aligned to sit to the right of the selection column. Leading `null` placeholders in `columns` are skipped when locating the first sticky data column.
+
+When multiple leading data columns are sticky (for example, favorites and name), mark each with `isStickyColumn: true`, set a narrow `stickyMinWidth` on the first column in `columns` (for example `3rem` for a favorites-only cell), leave that cell's content empty (`cell: null`) so only the favorite star renders, and set `hasRightBorder: true` only on the last column in that group.
 
 ### Sticky header and columns example
 

--- a/packages/module/src/DataViewTable/index.ts
+++ b/packages/module/src/DataViewTable/index.ts
@@ -1,2 +1,3 @@
 export { default } from './DataViewTable';
 export * from './DataViewTable';
+export * from './stickySelectionColumn';

--- a/packages/module/src/DataViewTable/stickySelectionColumn.test.ts
+++ b/packages/module/src/DataViewTable/stickySelectionColumn.test.ts
@@ -1,0 +1,112 @@
+import {
+  mergeFirstStickyDataColumnProps,
+  shouldIncludeStickySelectionColumn,
+  STICKY_SELECTION_COLUMN_WIDTH,
+  stickySelectionCellProps,
+} from './stickySelectionColumn';
+
+describe('stickySelectionColumn', () => {
+  describe('stickySelectionCellProps', () => {
+    it('matches row-selection sticky grouping props', () => {
+      expect(stickySelectionCellProps).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: false,
+        stickyMinWidth: STICKY_SELECTION_COLUMN_WIDTH,
+      });
+    });
+  });
+
+  describe('shouldIncludeStickySelectionColumn', () => {
+    it('is true when table is sticky, selectable, and first column is sticky', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          true,
+          true
+        )
+      ).toBe(true);
+    });
+
+    it('is false when table is not sticky', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          true,
+          false
+        )
+      ).toBe(false);
+    });
+
+    it('is false when not selectable', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          false,
+          true
+        )
+      ).toBe(false);
+    });
+
+    it('is false when first column is not sticky', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: false } } ],
+          true,
+          true
+        )
+      ).toBe(false);
+    });
+
+    it('is false when columns is empty', () => {
+      expect(shouldIncludeStickySelectionColumn([], true, true)).toBe(false);
+    });
+
+    it('is false when first column entry is null', () => {
+      expect(
+        shouldIncludeStickySelectionColumn([ null, { cell: 'Name', props: { isStickyColumn: true } } ], true, true)
+      ).toBe(false);
+    });
+  });
+
+  describe('mergeFirstStickyDataColumnProps', () => {
+    it('adds stickyLeftOffset when including selection sticky', () => {
+      expect(
+        mergeFirstStickyDataColumnProps(
+          { isStickyColumn: true, hasRightBorder: true },
+          true
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: true,
+        stickyLeftOffset: STICKY_SELECTION_COLUMN_WIDTH,
+      });
+    });
+
+    it('preserves existing stickyLeftOffset', () => {
+      expect(
+        mergeFirstStickyDataColumnProps(
+          { isStickyColumn: true, stickyLeftOffset: '80px' },
+          true
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        stickyLeftOffset: '80px',
+      });
+    });
+
+    it('does not merge when first column is not sticky', () => {
+      expect(
+        mergeFirstStickyDataColumnProps({ isStickyColumn: false }, true)
+      ).toEqual({ isStickyColumn: false });
+    });
+
+    it('returns column props unchanged when not including sticky selection', () => {
+      const props = { isStickyColumn: true, hasRightBorder: true };
+      expect(mergeFirstStickyDataColumnProps(props, false)).toBe(props);
+    });
+
+    it('returns undefined when column props are undefined', () => {
+      expect(mergeFirstStickyDataColumnProps(undefined, true)).toBeUndefined();
+    });
+  });
+});

--- a/packages/module/src/DataViewTable/stickySelectionColumn.test.ts
+++ b/packages/module/src/DataViewTable/stickySelectionColumn.test.ts
@@ -1,0 +1,227 @@
+import {
+  computeStickyLeftOffset,
+  getFirstStickyColumnIndex,
+  mergeFirstStickyDataColumnProps,
+  mergeLeadingStickyDataColumnProps,
+  shouldIncludeStickySelectionColumn,
+  STICKY_SELECTION_COLUMN_WIDTH,
+  stickySelectionCellProps,
+} from './stickySelectionColumn';
+
+describe('stickySelectionColumn', () => {
+  describe('stickySelectionCellProps', () => {
+    it('matches row-selection sticky grouping props', () => {
+      expect(stickySelectionCellProps).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: false,
+        stickyMinWidth: STICKY_SELECTION_COLUMN_WIDTH,
+      });
+    });
+  });
+
+  describe('getFirstStickyColumnIndex', () => {
+    it('returns the first sticky column index', () => {
+      expect(
+        getFirstStickyColumnIndex([
+          null,
+          { cell: 'Name', props: { isStickyColumn: true } },
+          { cell: 'Tags' },
+        ])
+      ).toBe(1);
+    });
+
+    it('returns -1 when no sticky column exists', () => {
+      expect(getFirstStickyColumnIndex([ { cell: 'Name' } ])).toBe(-1);
+    });
+  });
+
+  describe('shouldIncludeStickySelectionColumn', () => {
+    it('is true when table is sticky, selectable, and first sticky column exists', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          true,
+          true
+        )
+      ).toBe(true);
+    });
+
+    it('is true when the first sticky column follows a null placeholder', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ null, { cell: 'Name', props: { isStickyColumn: true } } ],
+          true,
+          true
+        )
+      ).toBe(true);
+    });
+
+    it('is false when table is not sticky', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          true,
+          false
+        )
+      ).toBe(false);
+    });
+
+    it('is false when not selectable', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          false,
+          true
+        )
+      ).toBe(false);
+    });
+
+    it('is false when no column is sticky', () => {
+      expect(
+        shouldIncludeStickySelectionColumn(
+          [ { cell: 'Name', props: { isStickyColumn: false } } ],
+          true,
+          true
+        )
+      ).toBe(false);
+    });
+
+    it('is false when columns is empty', () => {
+      expect(shouldIncludeStickySelectionColumn([], true, true)).toBe(false);
+    });
+  });
+
+  describe('computeStickyLeftOffset', () => {
+    const leadingStickyColumns = [
+      { cell: '', props: { isStickyColumn: true, stickyMinWidth: '3rem' } },
+      { cell: 'Name', props: { isStickyColumn: true, hasRightBorder: true } },
+      { cell: 'Tags' },
+    ];
+
+    it('returns the first sticky column width when selection is not included', () => {
+      expect(computeStickyLeftOffset(leadingStickyColumns, 1, false)).toBe('3rem');
+    });
+
+    it('combines selection and first sticky column widths', () => {
+      expect(computeStickyLeftOffset(leadingStickyColumns, 1, true)).toBe(
+        `calc(${STICKY_SELECTION_COLUMN_WIDTH} + 3rem)`
+      );
+    });
+
+    it('returns selection width for the first sticky data column when only one sticky column exists', () => {
+      expect(
+        computeStickyLeftOffset([ { cell: 'Name', props: { isStickyColumn: true } } ], 0, true)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('mergeFirstStickyDataColumnProps', () => {
+    it('adds stickyLeftOffset when including selection sticky', () => {
+      expect(
+        mergeFirstStickyDataColumnProps(
+          { isStickyColumn: true, hasRightBorder: true },
+          true
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: true,
+        stickyLeftOffset: STICKY_SELECTION_COLUMN_WIDTH,
+      });
+    });
+
+    it('preserves existing stickyLeftOffset', () => {
+      expect(
+        mergeFirstStickyDataColumnProps(
+          { isStickyColumn: true, stickyLeftOffset: '80px' },
+          true
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        stickyLeftOffset: '80px',
+      });
+    });
+
+    it('does not merge when first column is not sticky', () => {
+      expect(
+        mergeFirstStickyDataColumnProps({ isStickyColumn: false }, true)
+      ).toEqual({ isStickyColumn: false });
+    });
+
+    it('returns column props unchanged when not including sticky selection', () => {
+      const props = { isStickyColumn: true, hasRightBorder: true };
+      expect(mergeFirstStickyDataColumnProps(props, false)).toBe(props);
+    });
+
+    it('returns undefined when column props are undefined', () => {
+      expect(mergeFirstStickyDataColumnProps(undefined, true)).toBeUndefined();
+    });
+  });
+
+  describe('mergeLeadingStickyDataColumnProps', () => {
+    const leadingStickyColumns = [
+      { cell: '', props: { isStickyColumn: true, stickyMinWidth: '3rem' } },
+      { cell: 'Name', props: { isStickyColumn: true, hasRightBorder: true } },
+      { cell: 'Tags' },
+    ];
+
+    it('offsets the second sticky column from the columns definition', () => {
+      expect(
+        mergeLeadingStickyDataColumnProps(
+          { isStickyColumn: true, hasRightBorder: true },
+          1,
+          leadingStickyColumns,
+          false
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: true,
+        stickyLeftOffset: '3rem',
+      });
+    });
+
+    it('uses the columns definition stickyMinWidth for body cells', () => {
+      expect(
+        mergeLeadingStickyDataColumnProps(
+          { isStickyColumn: true, stickyMinWidth: '4rem' },
+          0,
+          leadingStickyColumns,
+          false
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        stickyMinWidth: '3rem',
+        style: { width: '3rem', minWidth: '3rem', maxWidth: '3rem' },
+      });
+    });
+
+    it('applies selection offset on the first sticky data column', () => {
+      expect(
+        mergeLeadingStickyDataColumnProps(
+          { isStickyColumn: true, hasRightBorder: true },
+          0,
+          [ { cell: 'Name', props: { isStickyColumn: true } } ],
+          true
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: true,
+        stickyLeftOffset: STICKY_SELECTION_COLUMN_WIDTH,
+      });
+    });
+
+    it('combines selection and leading sticky offsets for later sticky columns', () => {
+      expect(
+        mergeLeadingStickyDataColumnProps(
+          { isStickyColumn: true, hasRightBorder: true },
+          1,
+          leadingStickyColumns,
+          true
+        )
+      ).toEqual({
+        isStickyColumn: true,
+        hasRightBorder: true,
+        stickyLeftOffset: `calc(${STICKY_SELECTION_COLUMN_WIDTH} + 3rem)`,
+      });
+    });
+  });
+});

--- a/packages/module/src/DataViewTable/stickySelectionColumn.ts
+++ b/packages/module/src/DataViewTable/stickySelectionColumn.ts
@@ -1,0 +1,56 @@
+import { TdProps, ThProps } from '@patternfly/react-table';
+
+/**
+ * Min width / left offset for the row-selection column when it is grouped with a sticky first data column.
+ * Matches PatternFly’s typical checkbox column width so the Name column’s sticky inset aligns.
+ */
+export const STICKY_SELECTION_COLUMN_WIDTH = '4rem';
+
+/** Props applied to the injected checkbox Th/Td when they participate in a sticky first-column group */
+export const stickySelectionCellProps: Pick<
+  ThProps,
+  'isStickyColumn' | 'hasRightBorder' | 'stickyMinWidth'
+> = {
+  isStickyColumn: true,
+  hasRightBorder: false,
+  stickyMinWidth: STICKY_SELECTION_COLUMN_WIDTH,
+};
+
+/** `columns[0]` object shape from {@link DataViewTh} (avoids importing DataViewTable and a circular dependency). */
+function isStickyFirstColumnDefinition(column: unknown): boolean {
+  return (
+    column != null &&
+    typeof column === 'object' &&
+    'props' in column &&
+    (column as { props?: { isStickyColumn?: boolean } }).props?.isStickyColumn === true
+  );
+}
+
+export function shouldIncludeStickySelectionColumn(
+  columns: unknown[],
+  isSelectable: boolean,
+  isStickyTable: boolean
+): boolean {
+  if (!isStickyTable || !isSelectable || columns.length === 0) {
+    return false;
+  }
+  const first = columns[0];
+  if (first == null) {
+    return false;
+  }
+  return isStickyFirstColumnDefinition(first);
+}
+
+/** Adds horizontal inset so the first sticky data column sits after the sticky selection column */
+export function mergeFirstStickyDataColumnProps<P extends ThProps | TdProps>(
+  columnProps: P | undefined,
+  includeStickySelection: boolean
+): P | undefined {
+  if (!columnProps || !includeStickySelection || !columnProps.isStickyColumn) {
+    return columnProps;
+  }
+  return {
+    ...columnProps,
+    stickyLeftOffset: columnProps.stickyLeftOffset ?? STICKY_SELECTION_COLUMN_WIDTH,
+  };
+}

--- a/packages/module/src/DataViewTable/stickySelectionColumn.ts
+++ b/packages/module/src/DataViewTable/stickySelectionColumn.ts
@@ -1,0 +1,156 @@
+import { TdProps, ThProps } from '@patternfly/react-table';
+
+/**
+ * Min width / left offset for the row-selection column when it is grouped with a sticky first data column.
+ * Sized for a typical checkbox column; tune if your selection column renders wider.
+ */
+export const STICKY_SELECTION_COLUMN_WIDTH = '4rem';
+
+/** Default used when computing offsets for a preceding sticky column with no explicit stickyMinWidth. */
+export const DEFAULT_STICKY_COLUMN_WIDTH = '120px';
+
+/** Props applied to the injected checkbox Th/Td when they participate in a sticky first-column group */
+export const stickySelectionCellProps: Pick<
+  ThProps,
+  'isStickyColumn' | 'hasRightBorder' | 'stickyMinWidth'
+> = {
+  isStickyColumn: true,
+  hasRightBorder: false,
+  stickyMinWidth: STICKY_SELECTION_COLUMN_WIDTH,
+};
+
+function isStickyColumnDefinition(column: unknown): boolean {
+  return (
+    column != null &&
+    typeof column === 'object' &&
+    'props' in column &&
+    (column as { props?: { isStickyColumn?: boolean } }).props?.isStickyColumn === true
+  );
+}
+
+function getStickyMinWidth(column: unknown): string | undefined {
+  if (column == null || typeof column !== 'object' || !('props' in column)) {
+    return undefined;
+  }
+  return (column as { props?: { stickyMinWidth?: string } }).props?.stickyMinWidth;
+}
+
+/** Index of the first column definition marked `isStickyColumn`, or -1 when none. */
+export function getFirstStickyColumnIndex(columns: unknown[]): number {
+  return columns.findIndex((column) => isStickyColumnDefinition(column));
+}
+
+export function shouldIncludeStickySelectionColumn(
+  columns: unknown[],
+  isSelectable: boolean,
+  isStickyTable: boolean
+): boolean {
+  if (!isStickyTable || !isSelectable || columns.length === 0) {
+    return false;
+  }
+  return getFirstStickyColumnIndex(columns) >= 0;
+}
+
+function sumCssWidths(first: string, second: string): string {
+  return `calc(${first} + ${second})`;
+}
+
+/** Applies column-definition stickyMinWidth to sticky cells and locks width to prevent shifting during scroll. */
+function applyColumnDefStickyWidth<P extends ThProps | TdProps>(
+  columnProps: P,
+  columnDefStickyMinWidth: string | undefined
+): P {
+  if (!columnDefStickyMinWidth) {
+    return columnProps;
+  }
+  return {
+    ...columnProps,
+    stickyMinWidth: columnDefStickyMinWidth,
+    style: {
+      ...columnProps.style,
+      width: columnDefStickyMinWidth,
+      minWidth: columnDefStickyMinWidth,
+      maxWidth: columnDefStickyMinWidth,
+    },
+  };
+}
+
+/**
+ * Combined inset for a sticky column from preceding sticky columns in `columns`
+ * and, when applicable, the injected selection column.
+ */
+export function computeStickyLeftOffset(
+  columns: unknown[],
+  colIndex: number,
+  includeStickySelection: boolean
+): string | undefined {
+  const firstStickyIndex = getFirstStickyColumnIndex(columns);
+  if (firstStickyIndex < 0 || colIndex <= firstStickyIndex) {
+    return undefined;
+  }
+
+  let offset: string | undefined = includeStickySelection ? STICKY_SELECTION_COLUMN_WIDTH : undefined;
+
+  for (let i = firstStickyIndex; i < colIndex; i++) {
+    if (!isStickyColumnDefinition(columns[i])) {
+      continue;
+    }
+    const width = getStickyMinWidth(columns[i]) ?? DEFAULT_STICKY_COLUMN_WIDTH;
+    offset = offset ? sumCssWidths(offset, width) : width;
+  }
+
+  return offset;
+}
+
+/** Adds horizontal inset so the first sticky data column sits after the sticky selection column */
+export function mergeFirstStickyDataColumnProps<P extends ThProps | TdProps>(
+  columnProps: P | undefined,
+  includeStickySelection: boolean
+): P | undefined {
+  if (!columnProps || !includeStickySelection || !columnProps.isStickyColumn) {
+    return columnProps;
+  }
+  return {
+    ...columnProps,
+    stickyLeftOffset: columnProps.stickyLeftOffset ?? STICKY_SELECTION_COLUMN_WIDTH,
+  };
+}
+
+/**
+ * Applies sticky offsets for a leading group of sticky columns (selection + data, or multiple data columns).
+ * Offsets are derived from the `columns` definition so header and body cells stay aligned while scrolling.
+ * Only the rightmost column in the group should use `hasRightBorder: true`; earlier columns should not.
+ */
+export function mergeLeadingStickyDataColumnProps<P extends ThProps | TdProps>(
+  columnProps: P | undefined,
+  colIndex: number,
+  columns: unknown[],
+  includeStickySelection: boolean
+): P | undefined {
+  if (!columnProps?.isStickyColumn) {
+    return columnProps;
+  }
+
+  const firstStickyIndex = getFirstStickyColumnIndex(columns);
+  if (firstStickyIndex < 0) {
+    return columnProps;
+  }
+
+  const columnDefStickyMinWidth = getStickyMinWidth(columns[colIndex]);
+  let merged: P = applyColumnDefStickyWidth(columnProps, columnDefStickyMinWidth);
+
+  if (merged.stickyLeftOffset != null) {
+    return merged;
+  }
+
+  if (includeStickySelection && colIndex === firstStickyIndex) {
+    return mergeFirstStickyDataColumnProps(merged, true);
+  }
+
+  const offset = computeStickyLeftOffset(columns, colIndex, includeStickySelection);
+  if (offset != null) {
+    merged = { ...merged, stickyLeftOffset: offset };
+  }
+
+  return merged;
+}

--- a/packages/module/src/DataViewTableBasic/DataViewTableBasic.test.tsx
+++ b/packages/module/src/DataViewTableBasic/DataViewTableBasic.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataView } from '../DataView';
+import { DataViewSelection } from '../InternalContext';
 import { DataViewTableBasic, ExpandableContent } from './DataViewTableBasic';
+import { DataViewTh } from '../DataViewTable';
 
 interface Repository {
   id: number;
@@ -30,6 +32,20 @@ const rows = repositories.map(({ id, name, branches, prs, workspaces, lastCommit
 ]);
 
 const columns = [ 'Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit' ];
+
+const stickyColumns: DataViewTh[] = [
+  { cell: 'Repositories', props: { isStickyColumn: true, hasRightBorder: true } },
+  'Branches',
+  'Pull requests',
+  'Workspaces',
+  'Last commit',
+];
+
+const mockSelection: DataViewSelection = {
+  onSelect: jest.fn(),
+  isSelected: jest.fn(() => false),
+  isSelectDisabled: jest.fn(() => false),
+};
 
 const expandableContents: ExpandableContent[] = [
   { rowId: 1, columnId: 1, content: <div>Branch details for Repository one</div> },
@@ -70,6 +86,33 @@ describe('DataViewTable component', () => {
       </DataView>
     );
     expect(container).toMatchSnapshot();
+  });
+
+  test('applies sticky classes to selection and first data cells when isSticky and first column is sticky', () => {
+    const stickyRows = repositories.map(({ id, name, branches, prs, workspaces, lastCommit }) => [
+      { id, cell: name, props: { isStickyColumn: true, hasRightBorder: true } },
+      branches,
+      prs,
+      workspaces,
+      lastCommit,
+    ]);
+
+    const { container } = render(
+      <DataView selection={mockSelection}>
+        <DataViewTableBasic
+          aria-label='Repositories table'
+          ouiaId={ouiaId}
+          columns={stickyColumns}
+          rows={stickyRows}
+          isSticky
+        />
+      </DataView>
+    );
+
+    const firstBodyRow = container.querySelector('tbody tr');
+    const bodyCells = firstBodyRow?.querySelectorAll('td');
+    expect(bodyCells?.[0]?.classList.contains('pf-v6-c-table__sticky-cell')).toBe(true);
+    expect(bodyCells?.[1]?.classList.contains('pf-v6-c-table__sticky-cell')).toBe(true);
   });
 
   test('when isExpandable cell should be clickable and expandable', async () => {

--- a/packages/module/src/DataViewTableBasic/DataViewTableBasic.tsx
+++ b/packages/module/src/DataViewTableBasic/DataViewTableBasic.tsx
@@ -12,6 +12,11 @@ import {
 import { useInternalContext } from '../InternalContext';
 import { DataViewTableHead } from '../DataViewTableHead';
 import { DataViewTh, DataViewTr, isDataViewTdObject, isDataViewTrObject } from '../DataViewTable';
+import {
+  mergeFirstStickyDataColumnProps,
+  shouldIncludeStickySelectionColumn,
+  stickySelectionCellProps,
+} from '../DataViewTable/stickySelectionColumn';
 import { DataViewState } from '../DataView/DataView';
 
 export interface ExpandableContent {
@@ -57,6 +62,11 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
   const { selection, activeState, isSelectable } = useInternalContext();
   const { onSelect, isSelected, isSelectDisabled } = selection ?? {};
 
+  const includeStickySelection = useMemo(
+    () => shouldIncludeStickySelectionColumn(columns, isSelectable, isSticky),
+    [ columns, isSelectable, isSticky ]
+  );
+
   const activeHeadState = useMemo(() => activeState ? headStates?.[activeState] : undefined, [ activeState, headStates ]);
   const activeBodyState = useMemo(() => activeState ? bodyStates?.[activeState] : undefined, [ activeState, bodyStates ]);
 
@@ -87,6 +97,7 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
         {isSelectable && (
           <Td
             key={`select-${rowIndex}`}
+            {...(includeStickySelection ? stickySelectionCellProps : {})}
             select={{
               rowIndex,
               onSelect: (_event, isSelecting) => {
@@ -102,10 +113,13 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
           const cellExpandableContent = isExpandable ? expandedRows?.find(
             (content) => content.rowId === rowId && content.columnId === colIndex
           ) : undefined;
+          const baseTdProps = cellIsObject ? (cell?.props ?? {}) : {};
+          const tdProps =
+            colIndex === 0 ? mergeFirstStickyDataColumnProps(baseTdProps, includeStickySelection) : baseTdProps;
           return (
             <Td
               key={colIndex}
-              {...(cellIsObject && (cell?.props ?? {}))}
+              {...tdProps}
               {...(cellExpandableContent != null && {
                 compoundExpand: {
                   isExpanded: isRowExpanded && expandedColIndex === colIndex,
@@ -149,7 +163,20 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
     } else {
       return rowContent;
     }
-  }), [ rows, isSelectable, isSelected, isSelectDisabled, onSelect, ouiaId, expandedRowsState, expandedColumnIndex, expandedRows, isExpandable, needsSeparateTbody ]);
+  }), [
+    rows,
+    isSelectable,
+    isSelected,
+    isSelectDisabled,
+    onSelect,
+    ouiaId,
+    expandedRowsState,
+    expandedColumnIndex,
+    expandedRows,
+    isExpandable,
+    needsSeparateTbody,
+    includeStickySelection,
+  ]);
 
   const bodyContent = activeBodyState || (needsSeparateTbody ? renderedRows : <Tbody>{renderedRows}</Tbody>);
 
@@ -158,7 +185,7 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
       <OuterScrollContainer>
         <InnerScrollContainer>
           <Table ref={tableRef} aria-label="Data table" ouiaId={ouiaId} isExpandable={isExpandable} hasAnimations {...props} isStickyHeader >
-            { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} /> }
+            { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} isSticky={isSticky} /> }
             { bodyContent }
           </Table>
         </InnerScrollContainer>
@@ -167,7 +194,7 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
   } else {
     return (
       <Table ref={tableRef} aria-label="Data table" ouiaId={ouiaId} isExpandable={isExpandable} hasAnimations {...props}>
-        { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} /> }
+        { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} isSticky={isSticky} /> }
         { bodyContent }
       </Table>
     );

--- a/packages/module/src/DataViewTableBasic/DataViewTableBasic.tsx
+++ b/packages/module/src/DataViewTableBasic/DataViewTableBasic.tsx
@@ -12,6 +12,11 @@ import {
 import { useInternalContext } from '../InternalContext';
 import { DataViewTableHead } from '../DataViewTableHead';
 import { DataViewTh, DataViewTr, isDataViewTdObject, isDataViewTrObject } from '../DataViewTable';
+import {
+  mergeLeadingStickyDataColumnProps,
+  shouldIncludeStickySelectionColumn,
+  stickySelectionCellProps,
+} from '../DataViewTable/stickySelectionColumn';
 import { DataViewState } from '../DataView/DataView';
 
 export interface ExpandableContent {
@@ -57,6 +62,11 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
   const { selection, activeState, isSelectable } = useInternalContext();
   const { onSelect, isSelected, isSelectDisabled } = selection ?? {};
 
+  const includeStickySelection = useMemo(
+    () => shouldIncludeStickySelectionColumn(columns, isSelectable, isSticky),
+    [ columns, isSelectable, isSticky ]
+  );
+
   const activeHeadState = useMemo(() => activeState ? headStates?.[activeState] : undefined, [ activeState, headStates ]);
   const activeBodyState = useMemo(() => activeState ? bodyStates?.[activeState] : undefined, [ activeState, bodyStates ]);
 
@@ -87,6 +97,7 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
         {isSelectable && (
           <Td
             key={`select-${rowIndex}`}
+            {...(includeStickySelection ? stickySelectionCellProps : {})}
             select={{
               rowIndex,
               onSelect: (_event, isSelecting) => {
@@ -102,10 +113,17 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
           const cellExpandableContent = isExpandable ? expandedRows?.find(
             (content) => content.rowId === rowId && content.columnId === colIndex
           ) : undefined;
+          const baseTdProps = cellIsObject ? (cell?.props ?? {}) : {};
+          const tdProps = mergeLeadingStickyDataColumnProps(
+            baseTdProps,
+            colIndex,
+            columns,
+            includeStickySelection
+          );
           return (
             <Td
               key={colIndex}
-              {...(cellIsObject && (cell?.props ?? {}))}
+              {...tdProps}
               {...(cellExpandableContent != null && {
                 compoundExpand: {
                   isExpanded: isRowExpanded && expandedColIndex === colIndex,
@@ -149,7 +167,20 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
     } else {
       return rowContent;
     }
-  }), [ rows, isSelectable, isSelected, isSelectDisabled, onSelect, ouiaId, expandedRowsState, expandedColumnIndex, expandedRows, isExpandable, needsSeparateTbody ]);
+  }), [
+    rows,
+    isSelectable,
+    isSelected,
+    isSelectDisabled,
+    onSelect,
+    ouiaId,
+    expandedRowsState,
+    expandedColumnIndex,
+    expandedRows,
+    isExpandable,
+    needsSeparateTbody,
+    includeStickySelection,
+  ]);
 
   const bodyContent = activeBodyState || (needsSeparateTbody ? renderedRows : <Tbody>{renderedRows}</Tbody>);
 
@@ -158,7 +189,7 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
       <OuterScrollContainer>
         <InnerScrollContainer>
           <Table ref={tableRef} aria-label="Data table" ouiaId={ouiaId} isExpandable={isExpandable} hasAnimations {...props} isStickyHeader >
-            { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} /> }
+            { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} isSticky={isSticky} /> }
             { bodyContent }
           </Table>
         </InnerScrollContainer>
@@ -167,7 +198,7 @@ export const DataViewTableBasic: FC<DataViewTableBasicProps> = ({
   } else {
     return (
       <Table ref={tableRef} aria-label="Data table" ouiaId={ouiaId} isExpandable={isExpandable} hasAnimations {...props}>
-        { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} /> }
+        { activeHeadState || <DataViewTableHead columns={columns} ouiaId={ouiaId} hasResizableColumns={hasResizableColumns} isSticky={isSticky} /> }
         { bodyContent }
       </Table>
     );

--- a/packages/module/src/DataViewTableHead/DataViewTableHead.test.tsx
+++ b/packages/module/src/DataViewTableHead/DataViewTableHead.test.tsx
@@ -1,10 +1,19 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Table } from '@patternfly/react-table';
 import { DataViewTableHead } from './DataViewTableHead';
 import { DataViewSelection } from '../InternalContext';
 import { DataView } from '../DataView';
+import { DataViewTh } from '../DataViewTable';
 
 const columns = [ 'Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit' ];
+
+const stickyFirstColumn: DataViewTh[] = [
+  { cell: 'Repositories', props: { isStickyColumn: true, hasRightBorder: true } },
+  'Branches',
+  'Pull requests',
+  'Workspaces',
+  'Last commit',
+];
 
 const ouiaId = 'HeaderExample';
 
@@ -44,6 +53,22 @@ describe('DataViewTableHead component', () => {
       </DataView>
     );
     expect(container).toMatchSnapshot();
+  });
+
+  test('applies sticky classes to selection and first column when isSticky and first column is sticky', () => {
+    render(
+      <DataView selection={mockSelection}>
+        <Table>
+          <DataViewTableHead columns={stickyFirstColumn} ouiaId={ouiaId} isSticky />
+        </Table>
+      </DataView>
+    );
+
+    const selectionTh = screen.getByText('Data selection table head cell').closest('th');
+    expect(selectionTh?.classList.contains('pf-v6-c-table__sticky-cell')).toBe(true);
+
+    const repositoriesTh = screen.getByRole('columnheader', { name: 'Repositories' });
+    expect(repositoriesTh.classList.contains('pf-v6-c-table__sticky-cell')).toBe(true);
   });
 });
 

--- a/packages/module/src/DataViewTableHead/DataViewTableHead.tsx
+++ b/packages/module/src/DataViewTableHead/DataViewTableHead.tsx
@@ -2,6 +2,11 @@ import { FC, useMemo } from 'react';
 import { Th, Thead, TheadProps, Tr } from '@patternfly/react-table';
 import { useInternalContext } from '../InternalContext';
 import { DataViewTh, isDataViewThObject } from '../DataViewTable';
+import {
+  mergeFirstStickyDataColumnProps,
+  shouldIncludeStickySelectionColumn,
+  stickySelectionCellProps,
+} from '../DataViewTable/stickySelectionColumn';
 import { DataViewTh as DataViewThElement } from '../DataViewTh/DataViewTh';
 
 /** extends TheadProps */
@@ -14,6 +19,8 @@ export interface DataViewTableHeadProps extends TheadProps {
   ouiaId?: string;
   /** @hide Indicates whether table is resizable */
   hasResizableColumns?: boolean;
+  /** When true with a sticky first data column and row selection, the selection column participates in the sticky group */
+  isSticky?: boolean;
 }
 
 export const DataViewTableHead: FC<DataViewTableHeadProps> = ({
@@ -21,15 +28,25 @@ export const DataViewTableHead: FC<DataViewTableHeadProps> = ({
   columns,
   ouiaId = 'DataViewTableHead',
   hasResizableColumns,
+  isSticky = false,
   ...props
 }: DataViewTableHeadProps) => {
-  const { selection } = useInternalContext();
+  const { selection, isSelectable } = useInternalContext();
   const { onSelect, isSelected } = selection ?? {};
+
+  const includeStickySelection = useMemo(
+    () => shouldIncludeStickySelectionColumn(columns, isSelectable, isSticky),
+    [ columns, isSelectable, isSticky ]
+  );
 
   const cells = useMemo(
     () => [
       onSelect && isSelected && !isTreeTable ? (
-        <Th key="row-select" screenReaderText="Data selection table head cell" />
+        <Th
+          key="row-select"
+          screenReaderText="Data selection table head cell"
+          {...(includeStickySelection ? stickySelectionCellProps : {})}
+        />
       ) : null,
       ...columns.map((column, index) => (
         <DataViewThElement
@@ -37,12 +54,15 @@ export const DataViewTableHead: FC<DataViewTableHeadProps> = ({
           content={isDataViewThObject(column) ? column.cell : column}
           resizableProps={isDataViewThObject(column) ? column.resizableProps : undefined}
           data-ouia-component-id={`${ouiaId}-th-${index}`}
-          thProps={isDataViewThObject(column) ? (column?.props ?? {}) : {}}
+          thProps={mergeFirstStickyDataColumnProps(
+            isDataViewThObject(column) ? (column?.props ?? {}) : {},
+            index === 0 && includeStickySelection
+          )}
           hasResizableColumns={hasResizableColumns}
         />
       ))
     ],
-    [ columns, ouiaId, onSelect, isSelected, isTreeTable, hasResizableColumns ]
+    [ columns, ouiaId, onSelect, isSelected, isTreeTable, hasResizableColumns, includeStickySelection ]
   );
 
   return (

--- a/packages/module/src/DataViewTableHead/DataViewTableHead.tsx
+++ b/packages/module/src/DataViewTableHead/DataViewTableHead.tsx
@@ -2,6 +2,11 @@ import { FC, useMemo } from 'react';
 import { Th, Thead, TheadProps, Tr } from '@patternfly/react-table';
 import { useInternalContext } from '../InternalContext';
 import { DataViewTh, isDataViewThObject } from '../DataViewTable';
+import {
+  mergeLeadingStickyDataColumnProps,
+  shouldIncludeStickySelectionColumn,
+  stickySelectionCellProps,
+} from '../DataViewTable/stickySelectionColumn';
 import { DataViewTh as DataViewThElement } from '../DataViewTh/DataViewTh';
 
 /** extends TheadProps */
@@ -14,6 +19,8 @@ export interface DataViewTableHeadProps extends TheadProps {
   ouiaId?: string;
   /** @hide Indicates whether table is resizable */
   hasResizableColumns?: boolean;
+  /** When true with a sticky first data column and row selection, the selection column participates in the sticky group */
+  isSticky?: boolean;
 }
 
 export const DataViewTableHead: FC<DataViewTableHeadProps> = ({
@@ -21,15 +28,25 @@ export const DataViewTableHead: FC<DataViewTableHeadProps> = ({
   columns,
   ouiaId = 'DataViewTableHead',
   hasResizableColumns,
+  isSticky = false,
   ...props
 }: DataViewTableHeadProps) => {
-  const { selection } = useInternalContext();
+  const { selection, isSelectable } = useInternalContext();
   const { onSelect, isSelected } = selection ?? {};
+
+  const includeStickySelection = useMemo(
+    () => shouldIncludeStickySelectionColumn(columns, isSelectable, isSticky),
+    [ columns, isSelectable, isSticky ]
+  );
 
   const cells = useMemo(
     () => [
       onSelect && isSelected && !isTreeTable ? (
-        <Th key="row-select" screenReaderText="Data selection table head cell" />
+        <Th
+          key="row-select"
+          screenReaderText="Data selection table head cell"
+          {...(includeStickySelection ? stickySelectionCellProps : {})}
+        />
       ) : null,
       ...columns.map((column, index) => (
         <DataViewThElement
@@ -37,12 +54,17 @@ export const DataViewTableHead: FC<DataViewTableHeadProps> = ({
           content={isDataViewThObject(column) ? column.cell : column}
           resizableProps={isDataViewThObject(column) ? column.resizableProps : undefined}
           data-ouia-component-id={`${ouiaId}-th-${index}`}
-          thProps={isDataViewThObject(column) ? (column?.props ?? {}) : {}}
+          thProps={mergeLeadingStickyDataColumnProps(
+            isDataViewThObject(column) ? (column?.props ?? {}) : {},
+            index,
+            columns,
+            includeStickySelection
+          )}
           hasResizableColumns={hasResizableColumns}
         />
       ))
     ],
-    [ columns, ouiaId, onSelect, isSelected, isTreeTable, hasResizableColumns ]
+    [ columns, ouiaId, onSelect, isSelected, isTreeTable, hasResizableColumns, includeStickySelection ]
   );
 
   return (


### PR DESCRIPTION
When attempting to make the first column in a table row sticky, it doesn't make the selection column sticky and the selection column will scroll with the rest of the table. This PR makes the selection column sticky along with the "first" column.